### PR TITLE
Yahooスポーツの選手個人ページのURLをスクレイピングして、DBに保存する処理をRakeタスクに追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'nokogiri'
+gem 'pry-rails'
 gem 'devise'
-gem "slim-rails"
-gem "html2slim"
+gem 'slim-rails'
+gem 'html2slim'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     devise (4.7.2)
@@ -113,6 +114,11 @@ GEM
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     pg (1.2.3)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
@@ -231,6 +237,7 @@ DEPENDENCIES
   listen (~> 3.2)
   nokogiri
   pg (>= 0.18, < 2.0)
+  pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
   sass-rails (>= 6)

--- a/app/models/batter_score.rb
+++ b/app/models/batter_score.rb
@@ -1,0 +1,38 @@
+class BatterScore
+  def initialize(scores, team)
+    @number = scores[0]
+    @url = scores[1]
+    @name = scores[2]
+    @team = team
+    @batting_average = scores[3]
+    @home_run = scores[10]
+    @runs_batted_in = scores[12]
+    @stolen_base = scores[19]
+    @on_base_percentage = scores[22]
+    @on_base_plus_slugging = scores[24]
+    @walks = scores[15]
+    @hit_by_pitch = scores[16]
+    @scoring_position_batting_average = scores[25]
+    @strikeout = scores[14]
+    @error = scores[26]
+  end
+
+  def reflect_in_db
+    batter = Batter.find_or_initialize_by(url: @url)
+    batter.update(number: @number,
+                  url: @url,
+                  name: @name,
+                  team: @team,
+                  batting_average: @batting_average,
+                  home_run: @home_run,
+                  runs_batted_in: @runs_batted_in,
+                  stolen_base: @stolen_base,
+                  on_base_percentage: @on_base_percentage,
+                  on_base_plus_slugging: @on_base_plus_slugging,
+                  walks: @walks,
+                  hit_by_pitch: @hit_by_pitch,
+                  scoring_position_batting_average: @scoring_position_batting_average,
+                  strikeout: @strikeout,
+                  error: @error)
+  end
+end

--- a/app/models/pitcher_score.rb
+++ b/app/models/pitcher_score.rb
@@ -1,0 +1,38 @@
+class PitcherScore
+  def initialize(scores, team)
+    @number = scores[0]
+    @url = scores[1]
+    @name = scores[2]
+    @team = team
+    @earned_run_average = scores[3]
+    @win = scores[9]
+    @lose = scores[10]
+    @strikeout = scores[18]
+    @innings_pitched = scores[15]
+    @pitched = scores[4]
+    @number_of_save = scores[13]
+    @hold_point = scores[12]
+    @strikeouts_per_nine_innings = scores[19]
+    @strikeout_to_walk_ratio = scores[27]
+    @walks_and_hits_per_innings_pitched = scores[28]
+  end
+
+  def reflect_in_db
+    pitcher = Pitcher.find_or_initialize_by(url: @url)
+    pitcher.update(number: @number,
+                   url: @url,
+                   name: @name,
+                   team: @team,
+                   earned_run_average: @earned_run_average,
+                   win: @win,
+                   lose: @lose,
+                   strikeout: @strikeout,
+                   innings_pitched: @innings_pitched,
+                   pitched: @pitched,
+                   number_of_save: @number_of_save,
+                   hold_point: @hold_point,
+                   strikeouts_per_nine_innings: @strikeouts_per_nine_innings,
+                   strikeout_to_walk_ratio: @strikeout_to_walk_ratio,
+                   walks_and_hits_per_innings_pitched: @walks_and_hits_per_innings_pitched)
+  end
+end

--- a/app/models/score_scraper.rb
+++ b/app/models/score_scraper.rb
@@ -1,0 +1,34 @@
+require 'open-uri'
+require 'nokogiri'
+
+class ScoreScraper
+  def initialize(url)
+    @url = url
+    @charset = nil
+    @html = html
+    @player_scores = []
+  end
+
+  def scrape
+    page = Nokogiri::HTML.parse(@html, nil, @charset)
+    table = page.css('#js-playerTable')
+    table.search('tr').each do |node|
+      data = []
+      node.search('td').each do |n|
+        data.push(n.at_css('a')[:href]) if n.at_css('a')
+        data << n.text.gsub(/\n/, '').lstrip
+      end
+      @player_scores << data unless data.empty?
+    end
+    @player_scores
+  end
+
+  private
+
+  def html
+    @html = URI.open(@url) do |f|
+      @charset = f.charset
+      f.read
+    end
+  end
+end

--- a/db/migrate/20201208073553_add_url_column_to_batters.rb
+++ b/db/migrate/20201208073553_add_url_column_to_batters.rb
@@ -1,5 +1,5 @@
 class AddUrlColumnToBatters < ActiveRecord::Migration[6.0]
   def change
-    add_column :batters, :url, :string, null: false
+    add_column :batters, :url, :string
   end
 end

--- a/db/migrate/20201208073553_add_url_column_to_batters.rb
+++ b/db/migrate/20201208073553_add_url_column_to_batters.rb
@@ -1,0 +1,5 @@
+class AddUrlColumnToBatters < ActiveRecord::Migration[6.0]
+  def change
+    add_column :batters, :url, :string, null: false
+  end
+end

--- a/db/migrate/20201208074039_add_url_column_to_pitchers.rb
+++ b/db/migrate/20201208074039_add_url_column_to_pitchers.rb
@@ -1,0 +1,5 @@
+class AddUrlColumnToPitchers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pitchers, :url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_29_060313) do
+ActiveRecord::Schema.define(version: 2020_12_08_074039) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "batters", force: :cascade do |t|
     t.string "number"
@@ -29,11 +32,12 @@ ActiveRecord::Schema.define(version: 2020_10_29_060313) do
     t.integer "error"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "url"
   end
 
   create_table "favorite_batters", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "batter_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "batter_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["batter_id"], name: "index_favorite_batters_on_batter_id"
@@ -41,8 +45,8 @@ ActiveRecord::Schema.define(version: 2020_10_29_060313) do
   end
 
   create_table "favorite_pitchers", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "pitcher_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "pitcher_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["pitcher_id"], name: "index_favorite_pitchers_on_pitcher_id"
@@ -66,6 +70,7 @@ ActiveRecord::Schema.define(version: 2020_10_29_060313) do
     t.float "walks_and_hits_per_innings_pitched"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "url"
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/scrape.rake
+++ b/lib/tasks/scrape.rake
@@ -31,27 +31,29 @@ namespace :scrape do
       table.search('tr').each do |node|
         data = []
         node.search('td').each do |n|
+          data.push(n.at_css('a')[:href]) if n.at_css('a')
           data << n.text.gsub(/\n/, '').lstrip
         end
         players_score << data unless data.empty?
       end
 
       players_score.map do |player_score|
-        batter = Batter.find_or_initialize_by(name: player_score[1], team: team)
+        batter = Batter.find_or_initialize_by(url: player_score[1])
         batter.update(number: player_score[0],
-                      name: player_score[1],
+                      url: player_score[1],
+                      name: player_score[2],
                       team: team,
-                      batting_average: player_score[2],
-                      home_run: player_score[9],
-                      runs_batted_in: player_score[11],
-                      stolen_base: player_score[18],
-                      on_base_percentage: player_score[21],
-                      on_base_plus_slugging: player_score[23],
-                      walks: player_score[14],
-                      hit_by_pitch: player_score[15],
-                      scoring_position_batting_average: player_score[24],
-                      strikeout: player_score[13],
-                      error: player_score[25])
+                      batting_average: player_score[3],
+                      home_run: player_score[10],
+                      runs_batted_in: player_score[12],
+                      stolen_base: player_score[19],
+                      on_base_percentage: player_score[22],
+                      on_base_plus_slugging: player_score[24],
+                      walks: player_score[15],
+                      hit_by_pitch: player_score[16],
+                      scoring_position_batting_average: player_score[25],
+                      strikeout: player_score[14],
+                      error: player_score[26])
       end
     end
   end
@@ -72,29 +74,29 @@ namespace :scrape do
       table.search('tr').each do |node|
         data = []
         node.search('td').each do |n|
+          data.push(n.at_css('a')[:href]) if n.at_css('a')
           data << n.text.gsub(/\n/, '').lstrip
         end
         players_score << data unless data.empty?
       end
 
-      binding.pry
-
       players_score.map do |player_score|
-        pitcher = Pitcher.find_or_initialize_by(name: player_score[1], team: team)
+        pitcher = Pitcher.find_or_initialize_by(url: player_score[1])
         pitcher.update(number: player_score[0],
-                       name: player_score[1],
+                       url: player_score[1],
+                       name: player_score[2],
                        team: team,
-                       earned_run_average: player_score[2],
-                       win: player_score[8],
-                       lose: player_score[9],
-                       strikeout: player_score[17],
-                       innings_pitched: player_score[14],
-                       pitched: player_score[3],
-                       number_of_save: player_score[12],
-                       hold_point: player_score[11],
-                       strikeouts_per_nine_innings: player_score[18],
-                       strikeout_to_walk_ratio: player_score[26],
-                       walks_and_hits_per_innings_pitched: player_score[27])
+                       earned_run_average: player_score[3],
+                       win: player_score[9],
+                       lose: player_score[10],
+                       strikeout: player_score[18],
+                       innings_pitched: player_score[15],
+                       pitched: player_score[4],
+                       number_of_save: player_score[13],
+                       hold_point: player_score[12],
+                       strikeouts_per_nine_innings: player_score[19],
+                       strikeout_to_walk_ratio: player_score[27],
+                       walks_and_hits_per_innings_pitched: player_score[28])
       end
     end
   end

--- a/lib/tasks/scrape.rake
+++ b/lib/tasks/scrape.rake
@@ -1,102 +1,35 @@
-require 'open-uri'
-require 'nokogiri'
-
-PLAYERS_SCORE_URL = { '西武' => 'https://baseball.yahoo.co.jp/npb/teams/7/memberlist?kind=',
-                      'ソフトバンク' => 'https://baseball.yahoo.co.jp/npb/teams/12/memberlist?kind=',
-                      '楽天' => 'https://baseball.yahoo.co.jp/npb/teams/376/memberlist?kind=',
-                      'ロッテ' => 'https://baseball.yahoo.co.jp/npb/teams/9/memberlist?kind=',
-                      '日本ハム' => 'https://baseball.yahoo.co.jp/npb/teams/8/memberlist?kind=',
-                      'オリックス' => 'https://baseball.yahoo.co.jp/npb/teams/11/memberlist?kind=',
-                      '巨人' => 'https://baseball.yahoo.co.jp/npb/teams/1/memberlist?kind=',
-                      'DeNA' => 'https://baseball.yahoo.co.jp/npb/teams/3/memberlist?kind=',
-                      '阪神' => 'https://baseball.yahoo.co.jp/npb/teams/5/memberlist?kind=',
-                      '広島' => 'https://baseball.yahoo.co.jp/npb/teams/6/memberlist?kind=',
-                      '中日' => 'https://baseball.yahoo.co.jp/npb/teams/4/memberlist?kind=',
-                      'ヤクルト' => 'https://baseball.yahoo.co.jp/npb/teams/2/memberlist?kind=' }.freeze
+TEAMS = { '西武' => 7,
+          'ソフトバンク' => 12,
+          '楽天' => 376,
+          'ロッテ' => 9,
+          '日本ハム' => 8,
+          'オリックス' => 11,
+          '巨人' => 1,
+          'DeNA' => 3,
+          '阪神' => 5,
+          '広島' => 6,
+          '中日' => 4,
+          'ヤクルト' => 2 }.freeze
 
 namespace :scrape do
   desc 'Yahooスポーツから野手の成績を取得'
   task batter_record: :environment do
-    batter_score_url = PLAYERS_SCORE_URL.map { |key, value| [key, value + 'b'] }.to_h
-    batter_score_url.each do |team, url|
-      charset = nil
-      html = URI.open(url) do |f|
-        charset = f.charset
-        f.read
-      end
-
-      page = Nokogiri::HTML.parse(html, nil, charset)
-      players_score = []
-      table = page.css('#js-playerTable')
-      table.search('tr').each do |node|
-        data = []
-        node.search('td').each do |n|
-          data.push(n.at_css('a')[:href]) if n.at_css('a')
-          data << n.text.gsub(/\n/, '').lstrip
-        end
-        players_score << data unless data.empty?
-      end
-
-      players_score.map do |player_score|
-        batter = Batter.find_or_initialize_by(url: player_score[1])
-        batter.update(number: player_score[0],
-                      url: player_score[1],
-                      name: player_score[2],
-                      team: team,
-                      batting_average: player_score[3],
-                      home_run: player_score[10],
-                      runs_batted_in: player_score[12],
-                      stolen_base: player_score[19],
-                      on_base_percentage: player_score[22],
-                      on_base_plus_slugging: player_score[24],
-                      walks: player_score[15],
-                      hit_by_pitch: player_score[16],
-                      scoring_position_batting_average: player_score[25],
-                      strikeout: player_score[14],
-                      error: player_score[26])
+    TEAMS.each do |team, number|
+      url = "https://baseball.yahoo.co.jp/npb/teams/#{number}/memberlist?kind=b"
+      player_scores = ScoreScraper.new(url).scrape
+      player_scores.each do |player_score|
+        BatterScore.new(player_score, team).reflect_in_db
       end
     end
   end
 
   desc 'Yahooスポーツから投手の成績を取得'
   task pitcher_record: :environment do
-    pitcher_score_url = PLAYERS_SCORE_URL.map { |key, value| [key, value + 'p'] }.to_h
-    pitcher_score_url.each do |team, url|
-      charset = nil
-      html = URI.open(url) do |f|
-        charset = f.charset
-        f.read
-      end
-
-      page = Nokogiri::HTML.parse(html, nil, charset)
-      players_score = []
-      table = page.css('#js-playerTable')
-      table.search('tr').each do |node|
-        data = []
-        node.search('td').each do |n|
-          data.push(n.at_css('a')[:href]) if n.at_css('a')
-          data << n.text.gsub(/\n/, '').lstrip
-        end
-        players_score << data unless data.empty?
-      end
-
-      players_score.map do |player_score|
-        pitcher = Pitcher.find_or_initialize_by(url: player_score[1])
-        pitcher.update(number: player_score[0],
-                       url: player_score[1],
-                       name: player_score[2],
-                       team: team,
-                       earned_run_average: player_score[3],
-                       win: player_score[9],
-                       lose: player_score[10],
-                       strikeout: player_score[18],
-                       innings_pitched: player_score[15],
-                       pitched: player_score[4],
-                       number_of_save: player_score[13],
-                       hold_point: player_score[12],
-                       strikeouts_per_nine_innings: player_score[19],
-                       strikeout_to_walk_ratio: player_score[27],
-                       walks_and_hits_per_innings_pitched: player_score[28])
+    TEAMS.each do |team, number|
+      url = "https://baseball.yahoo.co.jp/npb/teams/#{number}/memberlist?kind=p"
+      player_scores = ScoreScraper.new(url).scrape
+      player_scores.each do |player_score|
+        PitcherScore.new(player_score, team).reflect_in_db
       end
     end
   end

--- a/lib/tasks/scrape.rake
+++ b/lib/tasks/scrape.rake
@@ -1,22 +1,23 @@
 require 'open-uri'
 require 'nokogiri'
 
+PLAYERS_SCORE_URL = { '西武' => 'https://baseball.yahoo.co.jp/npb/teams/7/memberlist?kind=',
+                      'ソフトバンク' => 'https://baseball.yahoo.co.jp/npb/teams/12/memberlist?kind=',
+                      '楽天' => 'https://baseball.yahoo.co.jp/npb/teams/376/memberlist?kind=',
+                      'ロッテ' => 'https://baseball.yahoo.co.jp/npb/teams/9/memberlist?kind=',
+                      '日本ハム' => 'https://baseball.yahoo.co.jp/npb/teams/8/memberlist?kind=',
+                      'オリックス' => 'https://baseball.yahoo.co.jp/npb/teams/11/memberlist?kind=',
+                      '巨人' => 'https://baseball.yahoo.co.jp/npb/teams/1/memberlist?kind=',
+                      'DeNA' => 'https://baseball.yahoo.co.jp/npb/teams/3/memberlist?kind=',
+                      '阪神' => 'https://baseball.yahoo.co.jp/npb/teams/5/memberlist?kind=',
+                      '広島' => 'https://baseball.yahoo.co.jp/npb/teams/6/memberlist?kind=',
+                      '中日' => 'https://baseball.yahoo.co.jp/npb/teams/4/memberlist?kind=',
+                      'ヤクルト' => 'https://baseball.yahoo.co.jp/npb/teams/2/memberlist?kind=' }.freeze
+
 namespace :scrape do
   desc 'Yahooスポーツから野手の成績を取得'
   task batter_record: :environment do
-    batter_score_url = { '西武' => 'https://baseball.yahoo.co.jp/npb/teams/7/memberlist?kind=b',
-                         'ソフトバンク' => 'https://baseball.yahoo.co.jp/npb/teams/12/memberlist?kind=b',
-                         '楽天' => 'https://baseball.yahoo.co.jp/npb/teams/376/memberlist?kind=b',
-                         'ロッテ' => 'https://baseball.yahoo.co.jp/npb/teams/9/memberlist?kind=b',
-                         '日本ハム' => 'https://baseball.yahoo.co.jp/npb/teams/8/memberlist?kind=b',
-                         'オリックス' => 'https://baseball.yahoo.co.jp/npb/teams/11/memberlist?kind=b',
-                         '巨人' => 'https://baseball.yahoo.co.jp/npb/teams/1/memberlist?kind=b',
-                         'DeNA' => 'https://baseball.yahoo.co.jp/npb/teams/3/memberlist?kind=b',
-                         '阪神' => 'https://baseball.yahoo.co.jp/npb/teams/5/memberlist?kind=b',
-                         '広島' => 'https://baseball.yahoo.co.jp/npb/teams/6/memberlist?kind=b',
-                         '中日' => 'https://baseball.yahoo.co.jp/npb/teams/4/memberlist?kind=b',
-                         'ヤクルト' => 'https://baseball.yahoo.co.jp/npb/teams/2/memberlist?kind=b' }
-
+    batter_score_url = PLAYERS_SCORE_URL.map { |key, value| [key, value + 'b'] }.to_h
     batter_score_url.each do |team, url|
       charset = nil
       html = URI.open(url) do |f|
@@ -34,6 +35,7 @@ namespace :scrape do
         end
         players_score << data unless data.empty?
       end
+
       players_score.map do |player_score|
         batter = Batter.find_or_initialize_by(name: player_score[1], team: team)
         batter.update(number: player_score[0],
@@ -56,19 +58,7 @@ namespace :scrape do
 
   desc 'Yahooスポーツから投手の成績を取得'
   task pitcher_record: :environment do
-    pitcher_score_url = { '西武' => 'https://baseball.yahoo.co.jp/npb/teams/7/memberlist?kind=p',
-                          'ソフトバンク' => 'https://baseball.yahoo.co.jp/npb/teams/12/memberlist?kind=p',
-                          '楽天' => 'https://baseball.yahoo.co.jp/npb/teams/376/memberlist?kind=p',
-                          'ロッテ' => 'https://baseball.yahoo.co.jp/npb/teams/9/memberlist?kind=p',
-                          '日本ハム' => 'https://baseball.yahoo.co.jp/npb/teams/8/memberlist?kind=p',
-                          'オリックス' => 'https://baseball.yahoo.co.jp/npb/teams/11/memberlist?kind=p',
-                          '巨人' => 'https://baseball.yahoo.co.jp/npb/teams/1/memberlist?kind=p',
-                          'DeNA' => 'https://baseball.yahoo.co.jp/npb/teams/3/memberlist?kind=p',
-                          '阪神' => 'https://baseball.yahoo.co.jp/npb/teams/5/memberlist?kind=p',
-                          '広島' => 'https://baseball.yahoo.co.jp/npb/teams/6/memberlist?kind=p',
-                          '中日' => 'https://baseball.yahoo.co.jp/npb/teams/4/memberlist?kind=p',
-                          'ヤクルト' => 'https://baseball.yahoo.co.jp/npb/teams/2/memberlist?kind=p' }
-
+    pitcher_score_url = PLAYERS_SCORE_URL.map { |key, value| [key, value + 'p'] }.to_h
     pitcher_score_url.each do |team, url|
       charset = nil
       html = URI.open(url) do |f|
@@ -86,6 +76,9 @@ namespace :scrape do
         end
         players_score << data unless data.empty?
       end
+
+      binding.pry
+
       players_score.map do |player_score|
         pitcher = Pitcher.find_or_initialize_by(name: player_score[1], team: team)
         pitcher.update(number: player_score[0],


### PR DESCRIPTION
ref #31 

## 変更前の問題
`find_or_initialize_by`によってレコードの更新・新規作成処理を行う際に、"選手名"と"所属チーム"がどちらも一致する場合は更新、どちらかが一致しなければ新規作成という処理を行っていた。
しかし、同一チームに同姓同名の選手が所属している場合にバグが起きるほか、選手が移籍してしまった場合、前所属チームのレコードが残ったまま同一選手の新しいレコードが作成されてしまうという問題があった。

## 目的
Yahooスポーツの選手個人ページへのURLに選手固有のIDが含まれていたため、これをDBに保存し`find_or_initialize_by`の引数に与えることで上記の問題の解消にあたった。

## 変更点
- BattersテーブルとPitchersテーブルにurlカラムを追加
- 選手個人ページへのURLをスクレイピングしDBに保存する処理を追加した
- URLを`find_or_initialize_by`の引数に与え、更新・新規作成を判断する基準をURLとした

## 課題
- 例外処理を作成していないため、OpenURIやDBへの保存時に問題が発生した場合、その日の更新が成されない
