### PR TITLE
Vueコンポーネントで出ていたWarningを削除

### DIFF
--- a/app/javascript/AllTeams.vue
+++ b/app/javascript/AllTeams.vue
@@ -6,13 +6,13 @@
       <el-collapse v-model="activeNamesCentral" class="central-teams-box">
         <h2>セ・リーグ</h2>
         <el-collapse-item v-for="(formalName, team, i) in centralTeams" :key="team" :title="formalName" :name="i">
-          <team-players :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
+          <team-players v-if="isAllPlayersFetched && isRegisteredPlayersFetched" :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
         </el-collapse-item>
       </el-collapse>
       <el-collapse v-model="activeNamesPacific" class="pacific-teams-box">
         <h2>パ・リーグ</h2>
         <el-collapse-item v-for="(formalName, team, i) in pacificTeams" :key="team" :title="formalName" :name="i">
-          <team-players :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
+          <team-players v-if="isAllPlayersFetched && isRegisteredPlayersFetched" :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
         </el-collapse-item>
       </el-collapse>
     </div>
@@ -45,12 +45,22 @@ export default {
         オリックス: "オリックス・バファローズ"
       },
       players: [],
-      registeredPlayers: null
+      registeredPlayers: [],
+      isAllPlayersFetched: false,
+      isRegisteredPlayersFetched: false
     }
   },
   created() {
-    axios.get('/api/v1/players').then(response => this.players = response.data)
+    this.fetchAllPlayers()
     this.fetchRegisteredPlayers()
+  },
+  watch: {
+    players() {
+      this.isAllPlayersFetched = true
+    },
+    registeredPlayers() {
+      this.isRegisteredPlayersFetched = true
+    }
   },
   components: {
     TeamPlayers
@@ -58,6 +68,9 @@ export default {
   methods: {
     fetchRegisteredPlayers() {
       axios.get('/api/v1/registered_players').then(response => this.registeredPlayers = response.data)
+    },
+    fetchAllPlayers() {
+      axios.get('/api/v1/players').then(response => this.players = response.data)
     }
   }
 }

--- a/app/javascript/AllTeams.vue
+++ b/app/javascript/AllTeams.vue
@@ -6,13 +6,13 @@
       <el-collapse v-model="activeNamesCentral" class="central-teams-box">
         <h2>セ・リーグ</h2>
         <el-collapse-item v-for="(formalName, team, i) in centralTeams" :key="team" :title="formalName" :name="i">
-          <team-players v-if="isAllPlayersFetched && isRegisteredPlayersFetched" :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
+          <team-players v-if="showTeamPlayersComponent" :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
         </el-collapse-item>
       </el-collapse>
       <el-collapse v-model="activeNamesPacific" class="pacific-teams-box">
         <h2>パ・リーグ</h2>
         <el-collapse-item v-for="(formalName, team, i) in pacificTeams" :key="team" :title="formalName" :name="i">
-          <team-players v-if="isAllPlayersFetched && isRegisteredPlayersFetched" :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
+          <team-players v-if="showTeamPlayersComponent" :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
         </el-collapse-item>
       </el-collapse>
     </div>
@@ -46,31 +46,26 @@ export default {
       },
       players: [],
       registeredPlayers: [],
-      isAllPlayersFetched: false,
-      isRegisteredPlayersFetched: false
+      showTeamPlayersComponent: false
     }
   },
   created() {
-    this.fetchAllPlayers()
-    this.fetchRegisteredPlayers()
-  },
-  watch: {
-    players() {
-      this.isAllPlayersFetched = true
-    },
-    registeredPlayers() {
-      this.isRegisteredPlayersFetched = true
-    }
+    Promise.all([
+      this.fetchAllPlayers(),
+      this.fetchRegisteredPlayers()
+    ]).then(() => {
+      this.showTeamPlayersComponent = true
+    })
   },
   components: {
     TeamPlayers
   },
   methods: {
     fetchRegisteredPlayers() {
-      axios.get('/api/v1/registered_players').then(response => this.registeredPlayers = response.data)
+      return axios.get('/api/v1/registered_players').then(response => this.registeredPlayers = response.data)
     },
     fetchAllPlayers() {
-      axios.get('/api/v1/players').then(response => this.players = response.data)
+      return axios.get('/api/v1/players').then(response => this.players = response.data)
     }
   }
 }

--- a/app/javascript/RegisterButton.vue
+++ b/app/javascript/RegisterButton.vue
@@ -35,11 +35,6 @@ export default {
       require: true
     }
   },
-  watch: {
-    registeredPlayers(){
-      this.changeRegisteredValue()
-    }
-  },
   mounted() {
     this.changeRegisteredValue()
   },

--- a/app/javascript/TeamPlayers.vue
+++ b/app/javascript/TeamPlayers.vue
@@ -3,7 +3,7 @@
     <div class="batters-box">
       <h3>野手</h3>
       <el-table
-          :data="players[selectedTeam]['batters']"
+          :data="teamBatters[0]"
           style="width: 100%">
         <el-table-column
             prop="number"
@@ -26,7 +26,7 @@
     <div class="pitchers-box">
       <h3>投手</h3>
       <el-table
-          :data="players[selectedTeam]['pitchers']"
+          :data="teamPitchers[0]"
           style="width: 100%">
         <el-table-column
             prop="number"
@@ -53,18 +53,36 @@
 import RegisterButton from "./RegisterButton"
 
 export default {
+  data: function () {
+    return {
+      teamBatters: [],
+      teamPitchers: []
+    }
+  },
   props: {
     selectedTeam: {
       type: String,
       require: true
     },
     players: {
-      type: Object,
+      type: Array,
       require: true
     },
     registeredPlayers: {
       type: Object,
       require: true
+    }
+  },
+  mounted() {
+    this.divideTeamBatters()
+    this.divideTeamPitchers()
+  },
+  methods: {
+    divideTeamBatters() {
+      this.teamBatters.push(this.players.find(element => element.name === this.selectedTeam)['batters'])
+    },
+    divideTeamPitchers() {
+      this.teamPitchers.push(this.players.find(element => element.name === this.selectedTeam)['pitchers'])
     }
   },
   components: {

--- a/app/javascript/TeamPlayers.vue
+++ b/app/javascript/TeamPlayers.vue
@@ -74,15 +74,12 @@ export default {
     }
   },
   mounted() {
-    this.divideTeamBatters()
-    this.divideTeamPitchers()
+    this.teamBatters.push(this.divideTeam('batters'))
+    this.teamPitchers.push(this.divideTeam('pitchers'))
   },
   methods: {
-    divideTeamBatters() {
-      this.teamBatters.push(this.players.find(element => element.name === this.selectedTeam)['batters'])
-    },
-    divideTeamPitchers() {
-      this.teamPitchers.push(this.players.find(element => element.name === this.selectedTeam)['pitchers'])
+    divideTeam(playersType) {
+      return this.players.find(element => element.name === this.selectedTeam)[`${playersType}`]
     }
   },
   components: {

--- a/app/models/players_data_formatter.rb
+++ b/app/models/players_data_formatter.rb
@@ -7,14 +7,15 @@ class PlayersDataFormatter
   def initialize(batters, pitchers)
     @batters = batters
     @pitchers = pitchers
-    @all_data = {}
+    @all_data = []
   end
 
   def run
     AFFILIATION_TEAMS.each do |team|
       affiliation_batters = divide_players_into_teams(@batters, team)
       affiliation_pitchers = divide_players_into_teams(@pitchers, team)
-      @all_data[team] = {
+      @all_data << {
+        name: team,
         batters: sort_by_number(affiliation_batters),
         pitchers: sort_by_number(affiliation_pitchers)
       }


### PR DESCRIPTION
## 目的
チーム別選手一覧画面は一見問題なく動いていたが、選手データのaxiosでの読み込みより先に子コンポーネントがmountされてしまっていた。
子コンポーネントのmountedのライフサイクルフックに定義していたメソッドが選手データを参照していたため子コンポーネントの数だけ大量のWarningがconsoleに表示されていた。
この問題を解消するために以下の変更を行った。

## 変更箇所
- `players_data_formatter`クラスを修正し、連想配列を返すように変更
- その変更に伴い、全選手のデータを扱う`TeamPlayers.vue`のコードを修正

- axiosによる選手データの読み込みが終了してから、子コンポーネントの描画が行われるように変更

