### PR TITLE
CSSフレームワークの導入

### DIFF
--- a/app/javascript/css/application.css
+++ b/app/javascript/css/application.css
@@ -1,0 +1,1 @@
+@import "materialize-css/dist/css/materialize.min.css";

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,6 +3,6 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 
-import 'materialize-css/dist/js/materialize'
+import '../css/application.css'
 
 import '../all_teams.js'

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,4 +3,6 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 
+import 'materialize-css/dist/js/materialize'
+
 import '../all_teams.js'

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/webpacker": "4.3.0",
     "axios": "^0.21.0",
     "element-ui": "^2.14.1",
+    "materialize-css": "^1.0.0",
     "turbolinks": "^5.2.0",
     "vue": "^2.6.12",
     "vue-loader": "^15.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4383,6 +4383,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+materialize-css@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/materialize-css/-/materialize-css-1.0.0.tgz#8d5db1c4a81c6d65f3b2e2ca83a8e08daa24d1be"
+  integrity sha512-4/oecXl8y/1i8RDZvyvwAICyqwNoKU4or5uf8uoAd74k76KzZ0Llym4zhJ5lLNUskcqjO0AuMcvNyDkpz8Z6zw==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz"


### PR DESCRIPTION
## 目的
Vue.jsのコンポーネント内で使用するために導入したElementUIは、Railsのviewに直接書き込むHTMLでは使い勝手が悪そうだったので、CSSフレームワークのMateralizeを追加で導入した。

## 変更点
- Materializeをインストール
- 新たに`app/javascript`下に`css/application.css`を作成し、その中でMateralizeをimportする処理を記述
- `application.js`で上記のファイルを読み込む処理を追加
