### PR TITLE
CSSフレームワークによるスタイルの適用

### DIFF
--- a/app/controllers/registered_players_controller.rb
+++ b/app/controllers/registered_players_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class RegisteredPlayersController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     @favorite_batters = current_user.favorite_batters.all
     @favorite_pitchers = current_user.favorite_pitchers.all

--- a/app/javascript/AllTeams.vue
+++ b/app/javascript/AllTeams.vue
@@ -79,8 +79,8 @@ export default {
 
 <style lang="scss" scoped>
 /deep/ .el-collapse-item__header{
-  font-size: 25px;
+  font-size: 2rem;
   line-height: 40px;
-  height: 70px;
+  height: 72px;
 }
 </style>

--- a/app/javascript/AllTeams.vue
+++ b/app/javascript/AllTeams.vue
@@ -1,16 +1,19 @@
 <template>
-  <div id="app">
-    <h1>チーム別選手一覧</h1>
-    <hr>
-    <div class="container">
-      <el-collapse v-model="activeNamesCentral" class="central-teams-box">
-        <h2>セ・リーグ</h2>
+  <div id="app" class="row">
+    <div class="col s12">
+      <h4>チーム別選手一覧</h4>
+    </div>
+    <div class="col l6 s12">
+      <h5 style="font-weight: bold">セ・リーグ</h5>
+      <el-collapse v-model="activeNamesCentral">
         <el-collapse-item v-for="(formalName, team, i) in centralTeams" :key="team" :title="formalName" :name="i">
           <team-players v-if="showTeamPlayersComponent" :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
         </el-collapse-item>
       </el-collapse>
-      <el-collapse v-model="activeNamesPacific" class="pacific-teams-box">
-        <h2>パ・リーグ</h2>
+    </div>
+    <div class="col l6 s12">
+      <h5 style="font-weight: bold">パ・リーグ</h5>
+      <el-collapse v-model="activeNamesPacific">
         <el-collapse-item v-for="(formalName, team, i) in pacificTeams" :key="team" :title="formalName" :name="i">
           <team-players v-if="showTeamPlayersComponent" :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
         </el-collapse-item>
@@ -72,20 +75,12 @@ export default {
 </script>
 
 <style scoped>
-.container {
-  display: flex;
-  justify-content: center;
-}
-
-.central-teams-box, .pacific-teams-box {
-  width: 700px;
-  margin: 0 5px;
-}
 </style>
 
 <style lang="scss" scoped>
 /deep/ .el-collapse-item__header{
-  font-size: 17px;
-  font-weight: bold;
+  font-size: 25px;
+  line-height: 40px;
+  height: 70px;
 }
 </style>

--- a/app/javascript/RegisterButton.vue
+++ b/app/javascript/RegisterButton.vue
@@ -1,9 +1,9 @@
 <template>
   <div id="app">
-    <el-button type="danger" size="mini" round @click="releaseProcessing" v-if="isRegistered">
+    <el-button type="danger" size="small" round @click="releaseProcessing" v-if="isRegistered">
       解除
     </el-button>
-    <el-button type="success" size="mini" round @click="registerProcessing" v-else>
+    <el-button type="success" size="small" round @click="registerProcessing" v-else>
       登録
     </el-button>
   </div>

--- a/app/javascript/TeamPlayers.vue
+++ b/app/javascript/TeamPlayers.vue
@@ -9,12 +9,12 @@
         <el-table-column
             prop="number"
             label="背番号"
-            min-width="70">
+            min-width="72">
         </el-table-column>
         <el-table-column
             prop="name"
             label="名前"
-            min-width="170">
+            min-width="168">
         </el-table-column>
         <el-table-column
             min-width="80">
@@ -32,12 +32,12 @@
         <el-table-column
             prop="number"
             label="背番号"
-            min-width="70">
+            min-width="72">
         </el-table-column>
         <el-table-column
             prop="name"
             label="名前"
-            min-width="170">
+            min-width="168">
         </el-table-column>
         <el-table-column
             min-width="80">
@@ -95,9 +95,9 @@ export default {
 
 <style lang="scss" scoped>
 /deep/ .el-table th>.cell {
-  font-size: 16px;
+  font-size: 1rem;
 }
 /deep/ .el-table td>.cell {
-  font-size: 18px;
+  font-size: 1.3rem;
 }
 </style>

--- a/app/javascript/TeamPlayers.vue
+++ b/app/javascript/TeamPlayers.vue
@@ -1,29 +1,30 @@
 <template>
-  <div id="app" class="container">
-    <div class="batters-box">
+  <div id="app">
+    <div class="col s6">
       <h3>野手</h3>
       <el-table
           :data="teamBatters[0]"
-          style="width: 100%">
+          style="width: 100%"
+      >
         <el-table-column
             prop="number"
             label="背番号"
-            width="70">
+            min-width="70">
         </el-table-column>
         <el-table-column
             prop="name"
             label="名前"
-            width="170">
+            min-width="170">
         </el-table-column>
         <el-table-column
-            width="80">
+            min-width="80">
           <template slot-scope="scope">
             <register-button :selected-player-id="scope.row.id" :player-type="'batters'" :registered-players="registeredPlayers"></register-button>
           </template>
         </el-table-column>
       </el-table>
     </div>
-    <div class="pitchers-box">
+    <div class="col s6">
       <h3>投手</h3>
       <el-table
           :data="teamPitchers[0]"
@@ -31,15 +32,15 @@
         <el-table-column
             prop="number"
             label="背番号"
-            width="70">
+            min-width="70">
         </el-table-column>
         <el-table-column
             prop="name"
             label="名前"
-            width="170">
+            min-width="170">
         </el-table-column>
         <el-table-column
-            width="80">
+            min-width="80">
           <template slot-scope="scope">
             <register-button :selected-player-id="scope.row.id" :player-type="'pitchers'" :registered-players="registeredPlayers"></register-button>
           </template>
@@ -89,11 +90,4 @@ export default {
 </script>
 
 <style scoped>
-.container {
-  display: flex;
-}
-
-.batters-box, .pitchers-box {
-  width: 350px;
-}
 </style>

--- a/app/javascript/TeamPlayers.vue
+++ b/app/javascript/TeamPlayers.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
     <div class="col s6">
-      <h3>野手</h3>
+      <h5>野手</h5>
       <el-table
           :data="teamBatters[0]"
           style="width: 100%"
@@ -25,7 +25,7 @@
       </el-table>
     </div>
     <div class="col s6">
-      <h3>投手</h3>
+      <h5>投手</h5>
       <el-table
           :data="teamPitchers[0]"
           style="width: 100%">

--- a/app/javascript/TeamPlayers.vue
+++ b/app/javascript/TeamPlayers.vue
@@ -90,4 +90,14 @@ export default {
 </script>
 
 <style scoped>
+
+</style>
+
+<style lang="scss" scoped>
+/deep/ .el-table th>.cell {
+  font-size: 16px;
+}
+/deep/ .el-table td>.cell {
+  font-size: 18px;
+}
 </style>

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,15 +9,20 @@ html
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
-    header
-      nav
-        - if user_signed_in?
-          = link_to 'ログアウト', destroy_user_session_path, method: :delete
-          |   |
-          = link_to '登録済の選手一覧', registered_players_path
-          |   |
-          = link_to '選手一覧', players_path
+    header.row
+      nav.col.s12.indigo.darken-4
+        div.nav-wrapper
+          a.brand-logo.center ProspectsWatcher
+          ul.left.hide-on-med-and-down#nav-mobile
+            - if user_signed_in?
+              li
+                = link_to 'ログアウト', destroy_user_session_path, method: :delete
+              li
+                = link_to '登録済の選手一覧', registered_players_path
+              li
+                = link_to '選手一覧', players_path
     .notifications
       - flash.each do |key, value|
         = content_tag(:div, value, class: key)
     = yield
+

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,7 +11,7 @@ html
   body
     header.row
       nav.col.s12.indigo.darken-4
-        div.nav-wrapper
+        .nav-wrapper
           a.brand-logo.center ProspectsWatcher
           ul.left.hide-on-med-and-down#nav-mobile
             - if user_signed_in?
@@ -25,4 +25,6 @@ html
       - flash.each do |key, value|
         = content_tag(:div, value, class: key)
     = yield
+    footer.page-footer.indigo.darken-4
+      .center 2020 CopyrightText
 

--- a/app/views/registered_players/index.html.slim
+++ b/app/views/registered_players/index.html.slim
@@ -1,147 +1,150 @@
-h1
-  | 登録選手一覧
-h2
-  | 野手
-table
-  thead
-    tr
-      th
-        | 背番号
-      th
-        | 選手名
-      th
-        | 所属チーム
-      th
-        | 打率
-      th
-        | HR
-      th
-        | 打点
-      th
-        | 盗塁
-      th
-        | 出塁率
-      th
-        | OPS
-      th
-        | 四球
-      th
-        | 死球
-      th
-        | 得点圏
-      th
-        | 三振
-      th
-        | エラー
-      th
-        | 更新日時
-      th[colspan="3"]
-  tbody
-    - @favorite_batters.each do |favorite_batter|
-      - batter = favorite_batter.batter
-      tr
-        td
-          = batter.number
-        td
-          = batter.name
-        td
-          = batter.team
-        td
-          = batter.batting_average
-        td
-          = batter.home_run
-        td
-          = batter.runs_batted_in
-        td
-          = batter.stolen_base
-        td
-          = batter.on_base_percentage
-        td
-          = batter.on_base_plus_slugging
-        td
-          = batter.walks
-        td
-          = batter.hit_by_pitch
-        td
-          = batter.scoring_position_batting_average
-        td
-          = batter.strikeout
-        td
-          = batter.error
-        td
-          = batter.updated_at
-        td
-          = link_to "登録解除", api_v1_favorite_batters_path(player_id: batter.id), method: :delete
-br
-h2
-  | 投手
-table
-  thead
-    tr
-      th
-        | 背番号
-      th
-        | 選手名
-      th
-        | 所属チーム
-      th
-        | 防御率
-      th
-        | 勝
-      th
-        | 負
-      th
-        | 三振
-      th
-        | 投球回
-      th
-        | 登板
-      th
-        | セーブ
-      th
-        | HP
-      th
-        | 奪三振率
-      th
-        | K/BB
-      th
-        | WHIP
-      th
-        | 更新日時
-      th[colspan="3"]
-  tbody
-    - @favorite_pitchers.each do |favorite_pitcher|
-      - pitcher = favorite_pitcher.pitcher
-      tr
-        td
-          = pitcher.number
-        td
-          = pitcher.name
-        td
-          = pitcher.team
-        td
-          = pitcher.earned_run_average
-        td
-          = pitcher.win
-        td
-          = pitcher.lose
-        td
-          = pitcher.strikeout
-        td
-          = pitcher.innings_pitched
-        td
-          = pitcher.pitched
-        td
-          = pitcher.number_of_save
-        td
-          = pitcher.hold_point
-        td
-          = pitcher.strikeouts_per_nine_innings
-        td
-          = pitcher.strikeout_to_walk_ratio
-        td
-          = pitcher.walks_and_hits_per_innings_pitched
-        td
-          = pitcher.updated_at
-        td
-          = link_to "登録解除", api_v1_favorite_pitchers_path(player_id: pitcher.id), method: :delete
+div.row
+  div.col.s12
+    h4 登録選手一覧
+    hr
+    div.col.s12
+      h5 野手
+      table
+        thead
+          tr
+            th
+              | 背番号
+            th
+              | 選手名
+            th
+              | 所属チーム
+            th
+              | 打率
+            th
+              | HR
+            th
+              | 打点
+            th
+              | 盗塁
+            th
+              | 出塁率
+            th
+              | OPS
+            th
+              | 四球
+            th
+              | 死球
+            th
+              | 得点圏
+            th
+              | 三振
+            th
+              | エラー
+            th
+              | 更新日時
+            th[colspan="3"]
+        tbody
+          - @favorite_batters.each do |favorite_batter|
+            - batter = favorite_batter.batter
+            tr
+              td
+                = batter.number
+              td
+                = batter.name
+              td
+                = batter.team
+              td
+                = batter.batting_average
+              td
+                = batter.home_run
+              td
+                = batter.runs_batted_in
+              td
+                = batter.stolen_base
+              td
+                = batter.on_base_percentage
+              td
+                = batter.on_base_plus_slugging
+              td
+                = batter.walks
+              td
+                = batter.hit_by_pitch
+              td
+                = batter.scoring_position_batting_average
+              td
+                = batter.strikeout
+              td
+                = batter.error
+              td
+                = batter.updated_at
+              td
+                = link_to "登録解除", api_v1_favorite_batters_path(player_id: batter.id), method: :delete
+    br
+    div.col.s12
+      h5 投手
+      table
+        thead
+          tr
+            th
+              | 背番号
+            th
+              | 選手名
+            th
+              | 所属チーム
+            th
+              | 防御率
+            th
+              | 勝
+            th
+              | 負
+            th
+              | 三振
+            th
+              | 投球回
+            th
+              | 登板
+            th
+              | セーブ
+            th
+              | HP
+            th
+              | 奪三振率
+            th
+              | K/BB
+            th
+              | WHIP
+            th
+              | 更新日時
+            th[colspan="3"]
+        tbody
+          - @favorite_pitchers.each do |favorite_pitcher|
+            - pitcher = favorite_pitcher.pitcher
+            tr
+              td
+                = pitcher.number
+              td
+                = pitcher.name
+              td
+                = pitcher.team
+              td
+                = pitcher.earned_run_average
+              td
+                = pitcher.win
+              td
+                = pitcher.lose
+              td
+                = pitcher.strikeout
+              td
+                = pitcher.innings_pitched
+              td
+                = pitcher.pitched
+              td
+                = pitcher.number_of_save
+              td
+                = pitcher.hold_point
+              td
+                = pitcher.strikeouts_per_nine_innings
+              td
+                = pitcher.strikeout_to_walk_ratio
+              td
+                = pitcher.walks_and_hits_per_innings_pitched
+              td
+                = pitcher.updated_at
+              td
+                = link_to "登録解除", api_v1_favorite_pitchers_path(player_id: pitcher.id), method: :delete
+    br


### PR DESCRIPTION
## 目的
Materializeを使用して、HTMLにスタイルを適用する。

## 変更点
- MaterializeのGridを使用して、レスポンシブにレイアウトが切り替わるようにHTMLを書き換えました
- ヘッダーとフッターを作成しました
- 一部コンポーネントのサイズやフォントサイズを調整しました

## 注意点
- レスポンシブデザインはレイアウトの切り替わりのみで、文字の大きさやボタンの大きさ等にはまだ適用できていません
- レスポンシブデザインの本格的な導入は後々行います
- 登録済の選手一覧画面は仮実装の状態なので最低限のデザインしか当てていません
- ログイン画面は #10 のIssueのPRでデザインを当てる予定です

**PC画面**
![image](https://user-images.githubusercontent.com/59789739/102582610-4c62ed80-4146-11eb-914f-d9cd725ec4c4.png)

**スマートフォン画面**
![image](https://user-images.githubusercontent.com/59789739/102582698-774d4180-4146-11eb-913d-8cda15bdb8c5.png)
