### PR TITLE
Herokuデプロイ時に起きているコンパイルエラーを解決

### DIFF
--- a/app/javascript/RegisterButton.vue
+++ b/app/javascript/RegisterButton.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-import { csrfToken } from 'rails-ujs'
+import { csrfToken } from '@rails/ujs'
 import axios from 'axios'
 
 axios.defaults.headers.common['X-CSRF-TOKEN'] = csrfToken()

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,7 +6,7 @@ html
     meta charset="utf-8"
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
     header


### PR DESCRIPTION
## 目的
#38 以降の自動デプロイ時に起きている`ModuleNotFoundError: Module not found: Error: Can't resolve 'rails-ujs' in '/tmp/build_f58a69b4_/app/javascript'`を解決する

## 変更点
- `RegisterButton.vue`の中で、CSRF対策として`import 'rails-ujs'`を`import '@rails/ujs'`に変更
- `application.html.slim`の中の`stylesheet_link_tag`を`stylesheet_pack_tag`に変更
