### PR TITLE
ユーザー情報編集ページの追加

### DIFF
--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -22,7 +22,7 @@
           br
           em
             = @minimum_password_length
-            |  characters minimum
+            |  文字以上
       .field
         = f.label :password_confirmation
         br

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -1,5 +1,5 @@
-.container
-  .container(style="margin: 80px auto;")
+.container.row
+  .col.s12.l8(style="margin: 72px auto; float: none;")
     h5
       | ユーザー情報の編集
     = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -1,42 +1,38 @@
-h2
-  | Edit 
-  = resource_name.to_s.humanize
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    br
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    div
-      | Currently waiting confirmation for: 
-      = resource.unconfirmed_email
-  .field
-    = f.label :password
-    i
-      | (leave blank if you don't want to change it)
-    br
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      br
-      em
-        = @minimum_password_length
-        |  characters minimum
-  .field
-    = f.label :password_confirmation
-    br
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    i
-      | (we need your current password to confirm your changes)
-    br
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-h3
-  | Cancel my account
-p
-  | Unhappy? 
-  = button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete
-= link_to "Back", :back
+.container
+  .container(style="margin: 80px auto;")
+    h5
+      | ユーザー情報の編集
+    = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+      = render "devise/shared/error_messages", resource: resource
+      .field
+        = f.label :email
+        br
+        = f.email_field :email, autofocus: true, autocomplete: "email"
+      - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+        div
+          | Currently waiting confirmation for:
+          = resource.unconfirmed_email
+      .field
+        = f.label :password
+        i
+          | (変更しない場合は空白)
+        br
+        = f.password_field :password, autocomplete: "new-password"
+        - if @minimum_password_length
+          br
+          em
+            = @minimum_password_length
+            |  characters minimum
+      .field
+        = f.label :password_confirmation
+        br
+        = f.password_field :password_confirmation, autocomplete: "new-password"
+      .field
+        = f.label :current_password
+        i
+          | (変更を反映する場合は現在のパスワードが必要です)
+        br
+        = f.password_field :current_password, autocomplete: "current-password", style: "margin-bottom: 24px;"
+      .actions
+        = f.submit "変更", class: 'btn-large waves-effect waves-light indigo darken-1 white-text', style: "margin-bottom:24px;"
+    = button_to "アカウント削除", registration_path(resource_name), data: { confirm: "アカウントを削除してもよろしいですか?" }, method: :delete, class: "btn-large waves-effect waves-light red darken-2 white-text"

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -14,23 +14,16 @@
           = resource.unconfirmed_email
       .field
         = f.label :password
-        i
-          | (変更しない場合は空白)
+        em(style="font-size: 0.9em; color: #9e9e9e")  半角英数6文字以上(変更しない場合は空白)
         br
         = f.password_field :password, autocomplete: "new-password"
-        - if @minimum_password_length
-          br
-          em
-            = @minimum_password_length
-            |  文字以上
       .field
         = f.label :password_confirmation
         br
         = f.password_field :password_confirmation, autocomplete: "new-password"
       .field
         = f.label :current_password
-        i
-          | (変更を反映する場合は現在のパスワードが必要です)
+        em(style="font-size: 0.9em; color: #9e9e9e")  変更を反映する場合は現在のパスワードが必要です
         br
         = f.password_field :current_password, autocomplete: "current-password", style: "margin-bottom: 24px;"
       .actions

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -10,11 +10,7 @@
         = f.email_field :email, autofocus: true, autocomplete: "email"
       .field
         = f.label :password
-        - if @minimum_password_length
-          em
-            | (
-            = @minimum_password_length
-            |  文字以上)
+        em(style="font-size: 0.9em; color: #9e9e9e")  半角英数6文字以上
         br
         = f.password_field :password, autocomplete: "new-password"
       .field

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,5 +1,5 @@
-.container
-  .container(style="margin: 120px auto;")
+.container.row
+  .col.s12.l8(style="margin: 120px auto; float: none;")
     h5
       | 新規登録
     = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,24 +1,26 @@
-h2
-  | Sign up
-= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    br
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .field
-    = f.label :password
-    - if @minimum_password_length
-      em
-        | (
-        = @minimum_password_length
-        |  characters minimum)
-    br
-    = f.password_field :password, autocomplete: "new-password"
-  .field
-    = f.label :password_confirmation
-    br
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .actions
-    = f.submit "Sign up"
-= render "devise/shared/links"
+.container
+  .container(style="margin: 120px auto;")
+    h5
+      | 新規登録
+    = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+      = render "devise/shared/error_messages", resource: resource
+      .field
+        = f.label :email
+        br
+        = f.email_field :email, autofocus: true, autocomplete: "email"
+      .field
+        = f.label :password
+        - if @minimum_password_length
+          em
+            | (
+            = @minimum_password_length
+            |  文字以上)
+        br
+        = f.password_field :password, autocomplete: "new-password"
+      .field
+        = f.label :password_confirmation
+        br
+        = f.password_field :password_confirmation, autocomplete: "new-password", style: "margin-bottom: 24px;"
+      .actions
+        = f.submit "登録", class: "btn-large waves-effect waves-light indigo darken-1 white-text"
+    = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,5 +1,5 @@
-.container
-  .container(style="margin: 160px auto;")
+.container.row
+  .col.s12.l8(style="margin: 160px auto; float: none;")
     h5
       |  ログイン
     = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,18 +1,16 @@
-h2
-  | Log in
-= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  .field
-    = f.label :email
-    br
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .field
-    = f.label :password
-    br
-    = f.password_field :password, autocomplete: "current-password"
-  - if devise_mapping.rememberable?
-    .field
-      = f.check_box :remember_me
-      = f.label :remember_me
-  .actions
-    = f.submit "Log in"
-= render "devise/shared/links"
+.container
+  .container(style="margin: 160px auto;")
+    h5
+      |  ログイン
+    = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+      .field
+        = f.label :email
+        br
+        = f.email_field :email, autofocus: true, autocomplete: "email"
+      .field
+        = f.label :password
+        br
+        = f.password_field :password, autocomplete: "current-password", style: "margin-bottom: 24px;"
+      .actions
+        = f.submit "ログイン", class: "btn-large waves-effect waves-light indigo darken-1 white-text", style: "margin-bottom: 24px;"
+    = render "devise/shared/links"

--- a/app/views/devise/shared/_links.html.slim
+++ b/app/views/devise/shared/_links.html.slim
@@ -1,19 +1,8 @@
-- if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(resource_name)
-  br
-- if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
-  br
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(resource_name)
+  = link_to "パスワードをお忘れですか?", new_password_path(resource_name)
   br
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
   = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
   br
 - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
   = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
-  br
-- if devise_mapping.omniauthable?
-  - resource_class.omniauth_providers.each do |provider|
-    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
-    br

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -23,6 +23,11 @@ html
                 = link_to 'ユーザー情報編集', edit_user_registration_path
               li
                 = link_to 'ログアウト', destroy_user_session_path, method: :delete
+            - else
+              - if controller_name != 'sessions'
+                = link_to "ログイン", new_session_path(resource_name)
+              - if devise_mapping.registerable? && controller_name != 'registrations'
+                = link_to "新規登録", new_registration_path(resource_name)
     .notifications
       - flash.each do |key, value|
         = content_tag(:div, value, class: key)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,23 +8,26 @@ html
     = csp_meta_tag
     = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
-  body
-    header.row
-      nav.col.s12.indigo.darken-4
+  body(style="display: flex; flex-direction: column; min-height: 100vh;")
+    header
+      nav.indigo.darken-4
         .nav-wrapper
           a.brand-logo.center ProspectsWatcher
           ul.left.hide-on-med-and-down#nav-mobile
             - if user_signed_in?
               li
-                = link_to 'ログアウト', destroy_user_session_path, method: :delete
-              li
                 = link_to '登録済の選手一覧', registered_players_path
               li
                 = link_to '選手一覧', players_path
+              li
+                = link_to 'ユーザー情報編集', edit_user_registration_path
+              li
+                = link_to 'ログアウト', destroy_user_session_path, method: :delete
     .notifications
       - flash.each do |key, value|
         = content_tag(:div, value, class: key)
-    = yield
+    .main(style="flex: 1 0 auto;")
+      = yield
     footer.page-footer.indigo.darken-4
       .center 2020 CopyrightText
 


### PR DESCRIPTION
ref #10 

## 目的
ユーザーの登録情報編集ページを作成する。

## 変更点
- ユーザーの登録情報編集ページへのリンクを追加
- ログインページ、新規登録ページ、ユーザー登録情報編集ページにそれぞれデザインを追加

## 注意点
- MaterializeにNotificationのフレームワークがなかったためNotificationのデザインは保留中です
- メール認証機能は別Issueで取り組みます

**○ユーザー情報編集画面**
![image](https://user-images.githubusercontent.com/59789739/102751906-0f983000-43ac-11eb-8fcb-523ae5899a34.png)


**○ログイン画面**
![image](https://user-images.githubusercontent.com/59789739/102751015-4705dd00-43aa-11eb-87c6-32e05ccecd15.png)


**○新規登録画面**
![image](https://user-images.githubusercontent.com/59789739/102751054-58e78000-43aa-11eb-88a0-a3913456742b.png)



