### PR TITLE
定数で定義しているチームの情報をDBに移行

### DIFF
--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -2,11 +2,9 @@
 
 class Api::V1::PlayersController < ActionController::API
   def index
-    batters = Batter.select(:id, :number, :name, :team)
-    pitchers = Pitcher.select(:id, :number, :name, :team)
-    players_data_formatter = PlayersDataFormatter.new(batters, pitchers)
-    players_data_formatter.run
-    players_data = players_data_formatter.all_data
+    teams = Team.order(:ranking)
+    players_data_formatter = PlayersDataFormatter.new(teams)
+    players_data = players_data_formatter.run
     render json: players_data
   end
 end

--- a/app/javascript/AllTeams.vue
+++ b/app/javascript/AllTeams.vue
@@ -40,7 +40,7 @@ export default {
   created() {
     Promise.all([
       this.fetchAllPlayers(),
-      this.fetchRegisteredPlayers(),
+      this.fetchRegisteredPlayers()
     ]).then(() => {
       this.showTeamPlayersComponent = true
     })

--- a/app/javascript/AllTeams.vue
+++ b/app/javascript/AllTeams.vue
@@ -6,16 +6,16 @@
     <div class="col l6 s12">
       <h5 style="font-weight: bold">セ・リーグ</h5>
       <el-collapse v-model="activeNamesCentral">
-        <el-collapse-item v-for="(formalName, team, i) in centralTeams" :key="team" :title="formalName" :name="i">
-          <team-players v-if="showTeamPlayersComponent" :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
+        <el-collapse-item v-for="(team, i) in teams['central']" :key="team['name']" :title="team['formal_name']" :name="i">
+          <team-players v-if="showTeamPlayersComponent" :selected-team="team['name']" :same-league-teams="teams['central']" :registered-players="registeredPlayers"></team-players>
         </el-collapse-item>
       </el-collapse>
     </div>
     <div class="col l6 s12">
       <h5 style="font-weight: bold">パ・リーグ</h5>
       <el-collapse v-model="activeNamesPacific">
-        <el-collapse-item v-for="(formalName, team, i) in pacificTeams" :key="team" :title="formalName" :name="i">
-          <team-players v-if="showTeamPlayersComponent" :selected-team="team" :players="players" :registered-players="registeredPlayers"></team-players>
+        <el-collapse-item v-for="(team, i) in teams['pacific']" :key="team['name']" :title="team['formal_name']" :name="i">
+          <team-players v-if="showTeamPlayersComponent" :selected-team="team['name']" :same-league-teams="teams['pacific']" :registered-players="registeredPlayers"></team-players>
         </el-collapse-item>
       </el-collapse>
     </div>
@@ -31,31 +31,16 @@ export default {
     return {
       activeNamesCentral: ['1'],
       activeNamesPacific: ['1'],
-      centralTeams: {
-        巨人: "読売ジャイアンツ",
-        DeNA: "横浜DeNAベイスターズ",
-        阪神: "阪神タイガース",
-        広島: "広島東洋カープ",
-        中日: "中日ドラゴンズ",
-        ヤクルト: "東京ヤクルトスワローズ"
-      },
-      pacificTeams: {
-        西武: "埼玉西武ライオンズ",
-        ソフトバンク: "福岡ソフトバンクホークス",
-        楽天: "東北楽天ゴールデンイーグルス",
-        ロッテ: "千葉ロッテマリーンズ",
-        日本ハム: "北海道日本ハムファイターズ",
-        オリックス: "オリックス・バファローズ"
-      },
-      players: [],
+      teams: {},
       registeredPlayers: [],
-      showTeamPlayersComponent: false
+      showTeamPlayersComponent: false,
+      nowLoading: true
     }
   },
   created() {
     Promise.all([
       this.fetchAllPlayers(),
-      this.fetchRegisteredPlayers()
+      this.fetchRegisteredPlayers(),
     ]).then(() => {
       this.showTeamPlayersComponent = true
     })
@@ -68,7 +53,7 @@ export default {
       return axios.get('/api/v1/registered_players').then(response => this.registeredPlayers = response.data)
     },
     fetchAllPlayers() {
-      return axios.get('/api/v1/players').then(response => this.players = response.data)
+      return axios.get('/api/v1/players').then(response => this.teams = response.data)
     }
   }
 }

--- a/app/javascript/TeamPlayers.vue
+++ b/app/javascript/TeamPlayers.vue
@@ -65,7 +65,7 @@ export default {
       type: String,
       require: true
     },
-    players: {
+    sameLeagueTeams: {
       type: Array,
       require: true
     },
@@ -80,7 +80,7 @@ export default {
   },
   methods: {
     divideTeam(playersType) {
-      return this.players.find(element => element.name === this.selectedTeam)[`${playersType}`]
+      return this.sameLeagueTeams.find(element => element.name === this.selectedTeam)[`${playersType}`]
     }
   },
   components: {

--- a/app/models/batter.rb
+++ b/app/models/batter.rb
@@ -2,4 +2,5 @@
 
 class Batter < ApplicationRecord
   has_many :favorite_batters, dependent: :destroy
+  belongs_to :team
 end

--- a/app/models/batter_score.rb
+++ b/app/models/batter_score.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class BatterScore
-  def initialize(scores, team)
+  def initialize(scores, team_id)
     @number = scores[0]
     @url = scores[1]
     @name = scores[2]
-    @team = team
+    @team_id = team_id
     @batting_average = scores[3]
     @home_run = scores[10]
     @runs_batted_in = scores[12]
@@ -24,7 +24,7 @@ class BatterScore
     batter.update(number: @number,
                   url: @url,
                   name: @name,
-                  team: @team,
+                  team_id: @team_id,
                   batting_average: @batting_average,
                   home_run: @home_run,
                   runs_batted_in: @runs_batted_in,

--- a/app/models/pitcher.rb
+++ b/app/models/pitcher.rb
@@ -2,4 +2,5 @@
 
 class Pitcher < ApplicationRecord
   has_many :favorite_pitchers, dependent: :destroy
+  belongs_to :team
 end

--- a/app/models/pitcher_score.rb
+++ b/app/models/pitcher_score.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class PitcherScore
-  def initialize(scores, team)
+  def initialize(scores, team_id)
     @number = scores[0]
     @url = scores[1]
     @name = scores[2]
-    @team = team
+    @team_id = team_id
     @earned_run_average = scores[3]
     @win = scores[9]
     @lose = scores[10]
@@ -24,7 +24,7 @@ class PitcherScore
     pitcher.update(number: @number,
                    url: @url,
                    name: @name,
-                   team: @team,
+                   team_id: @team_id,
                    earned_run_average: @earned_run_average,
                    win: @win,
                    lose: @lose,

--- a/app/models/players_data_formatter.rb
+++ b/app/models/players_data_formatter.rb
@@ -1,32 +1,28 @@
 # frozen_string_literal: true
 
 class PlayersDataFormatter
-  AFFILIATION_TEAMS = %w[西武 ソフトバンク 楽天 ロッテ 日本ハム オリックス 巨人 DeNA 阪神 広島 中日 ヤクルト]
   attr_reader :all_data
 
-  def initialize(batters, pitchers)
-    @batters = batters
-    @pitchers = pitchers
-    @all_data = []
+  def initialize(teams)
+    @teams = teams
   end
 
   def run
-    AFFILIATION_TEAMS.each do |team|
-      affiliation_batters = divide_players_into_teams(@batters, team)
-      affiliation_pitchers = divide_players_into_teams(@pitchers, team)
-      @all_data << {
-        name: team,
-        batters: sort_by_number(affiliation_batters),
-        pitchers: sort_by_number(affiliation_pitchers)
+    all_data = {central: [], pacific: []}
+    @teams.each do |team|
+      batters = team.batters.select(:id, :number, :name)
+      pitchers = team.pitchers.select(:id, :number, :name)
+      all_data[team.league.to_sym] << {
+        name: team.name,
+        formal_name: team.formal_name,
+        batters: sort_by_number(batters),
+        pitchers: sort_by_number(pitchers)
       }
     end
+    all_data
   end
 
   private
-  def divide_players_into_teams(players, team)
-    players.select { |player| player.team == team }
-  end
-
   def sort_by_number(players)
     players.sort_by { |player| player.number.to_i }
   end

--- a/app/models/players_data_formatter.rb
+++ b/app/models/players_data_formatter.rb
@@ -8,7 +8,7 @@ class PlayersDataFormatter
   end
 
   def run
-    all_data = {central: [], pacific: []}
+    all_data = { central: [], pacific: [] }
     @teams.each do |team|
       batters = team.batters.select(:id, :number, :name)
       pitchers = team.pitchers.select(:id, :number, :name)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,0 +1,2 @@
+class Team < ApplicationRecord
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,3 +1,5 @@
 class Team < ApplicationRecord
   enum league: { central: 0, pacific: 1}
+  has_many :batters
+  has_many :pitchers
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,2 +1,3 @@
 class Team < ApplicationRecord
+  enum league: { central: 0, pacific: 1}
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class Team < ApplicationRecord
-  enum league: { central: 0, pacific: 1}
+  enum league: { central: 0, pacific: 1 }
   has_many :batters
   has_many :pitchers
 end

--- a/app/views/registered_players/index.html.slim
+++ b/app/views/registered_players/index.html.slim
@@ -47,7 +47,7 @@ div.row
               td
                 = batter.name
               td
-                = batter.team
+                = batter.team.name
               td
                 = batter.batting_average
               td
@@ -120,7 +120,7 @@ div.row
               td
                 = pitcher.name
               td
-                = pitcher.team
+                = pitcher.team.name
               td
                 = pitcher.earned_run_average
               td

--- a/db/migrate/20201221081504_create_teams.rb
+++ b/db/migrate/20201221081504_create_teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateTeams < ActiveRecord::Migration[6.0]
   def change
     create_table :teams do |t|

--- a/db/migrate/20201221081504_create_teams.rb
+++ b/db/migrate/20201221081504_create_teams.rb
@@ -1,0 +1,12 @@
+class CreateTeams < ActiveRecord::Migration[6.0]
+  def change
+    create_table :teams do |t|
+      t.string :name, null: false
+      t.string :formal_name, null: false
+      t.integer :ranking, null: false
+      t.integer :league, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201222003422_add_url_id_column_to_teams.rb
+++ b/db/migrate/20201222003422_add_url_id_column_to_teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUrlIdColumnToTeams < ActiveRecord::Migration[6.0]
   def change
     add_column :teams, :url_id, :integer, null: false

--- a/db/migrate/20201222003422_add_url_id_column_to_teams.rb
+++ b/db/migrate/20201222003422_add_url_id_column_to_teams.rb
@@ -1,0 +1,5 @@
+class AddUrlIdColumnToTeams < ActiveRecord::Migration[6.0]
+  def change
+    add_column :teams, :url_id, :integer, null: false
+  end
+end

--- a/db/migrate/20201222012502_add_team_reference_to_batters.rb
+++ b/db/migrate/20201222012502_add_team_reference_to_batters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTeamReferenceToBatters < ActiveRecord::Migration[6.0]
   def change
     add_reference :batters, :team, index: true, foreign_key: true

--- a/db/migrate/20201222012502_add_team_reference_to_batters.rb
+++ b/db/migrate/20201222012502_add_team_reference_to_batters.rb
@@ -1,0 +1,5 @@
+class AddTeamReferenceToBatters < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :batters, :team, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20201222012509_add_team_reference_to_pitchers.rb
+++ b/db/migrate/20201222012509_add_team_reference_to_pitchers.rb
@@ -1,0 +1,5 @@
+class AddTeamReferenceToPitchers < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :pitchers, :team, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20201222012509_add_team_reference_to_pitchers.rb
+++ b/db/migrate/20201222012509_add_team_reference_to_pitchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTeamReferenceToPitchers < ActiveRecord::Migration[6.0]
   def change
     add_reference :pitchers, :team, index: true, foreign_key: true

--- a/db/migrate/20201222012839_remove_team_to_batters.rb
+++ b/db/migrate/20201222012839_remove_team_to_batters.rb
@@ -1,0 +1,5 @@
+class RemoveTeamToBatters < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :batters, :team, :string
+  end
+end

--- a/db/migrate/20201222012839_remove_team_to_batters.rb
+++ b/db/migrate/20201222012839_remove_team_to_batters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveTeamToBatters < ActiveRecord::Migration[6.0]
   def change
     remove_column :batters, :team, :string

--- a/db/migrate/20201222012845_remove_team_to_pitchers.rb
+++ b/db/migrate/20201222012845_remove_team_to_pitchers.rb
@@ -1,0 +1,5 @@
+class RemoveTeamToPitchers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :pitchers, :team, :string
+  end
+end

--- a/db/migrate/20201222012845_remove_team_to_pitchers.rb
+++ b/db/migrate/20201222012845_remove_team_to_pitchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveTeamToPitchers < ActiveRecord::Migration[6.0]
   def change
     remove_column :pitchers, :team, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_08_074039) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+ActiveRecord::Schema.define(version: 2020_12_21_081504) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +71,15 @@ ActiveRecord::Schema.define(version: 2020_12_08_074039) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "url"
+  end
+
+  create_table "teams", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "formal_name", null: false
+    t.integer "ranking", null: false
+    t.integer "league", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_21_081504) do
+ActiveRecord::Schema.define(version: 2020_12_22_003422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2020_12_21_081504) do
     t.integer "league", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "url_id", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_22_003422) do
+ActiveRecord::Schema.define(version: 2020_12_22_012845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,6 @@ ActiveRecord::Schema.define(version: 2020_12_22_003422) do
   create_table "batters", force: :cascade do |t|
     t.string "number"
     t.string "name"
-    t.string "team"
     t.string "batting_average"
     t.integer "home_run"
     t.integer "runs_batted_in"
@@ -33,6 +32,8 @@ ActiveRecord::Schema.define(version: 2020_12_22_003422) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "url"
+    t.bigint "team_id"
+    t.index ["team_id"], name: "index_batters_on_team_id"
   end
 
   create_table "favorite_batters", force: :cascade do |t|
@@ -56,7 +57,6 @@ ActiveRecord::Schema.define(version: 2020_12_22_003422) do
   create_table "pitchers", force: :cascade do |t|
     t.string "number"
     t.string "name"
-    t.string "team"
     t.float "earned_run_average"
     t.integer "win"
     t.integer "lose"
@@ -71,6 +71,8 @@ ActiveRecord::Schema.define(version: 2020_12_22_003422) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "url"
+    t.bigint "team_id"
+    t.index ["team_id"], name: "index_pitchers_on_team_id"
   end
 
   create_table "teams", force: :cascade do |t|
@@ -95,8 +97,10 @@ ActiveRecord::Schema.define(version: 2020_12_22_003422) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "batters", "teams"
   add_foreign_key "favorite_batters", "batters"
   add_foreign_key "favorite_batters", "users"
   add_foreign_key "favorite_pitchers", "pitchers"
   add_foreign_key "favorite_pitchers", "users"
+  add_foreign_key "pitchers", "teams"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,85 +3,85 @@
 Team.create!(
   [
     {
-      name: "ソフトバンク",
-      formal_name: "福岡ソフトバンクホークス",
+      name: 'ソフトバンク',
+      formal_name: '福岡ソフトバンクホークス',
       ranking: 1,
       league: :pacific,
       url_id: 12
     },
     {
-      name: "ロッテ",
-      formal_name: "千葉ロッテマリーンズ",
+      name: 'ロッテ',
+      formal_name: '千葉ロッテマリーンズ',
       ranking: 2,
       league: :pacific,
       url_id: 9
     },
     {
-      name: "西武",
-      formal_name: "埼玉西部ライオンズ",
+      name: '西武',
+      formal_name: '埼玉西部ライオンズ',
       ranking: 3,
       league: :pacific,
       url_id: 7
     },
     {
-      name: "楽天",
-      formal_name: "東北楽天ゴールデンイーグルス",
+      name: '楽天',
+      formal_name: '東北楽天ゴールデンイーグルス',
       ranking: 4,
       league: :pacific,
       url_id: 376
     },
     {
-      name: "日本ハム",
-      formal_name: "北海道日本ハムファイターズ",
+      name: '日本ハム',
+      formal_name: '北海道日本ハムファイターズ',
       ranking: 5,
       league: :pacific,
       url_id: 8
     },
     {
-      name: "オリックス",
-      formal_name: "オリックス・バファローズ",
+      name: 'オリックス',
+      formal_name: 'オリックス・バファローズ',
       ranking: 6,
       league: :pacific,
       url_id: 11
     },
     {
-      name: "巨人",
-      formal_name: "読売ジャイアンツ",
+      name: '巨人',
+      formal_name: '読売ジャイアンツ',
       ranking: 1,
       league: :central,
       url_id: 1
     },
     {
-      name: "阪神",
-      formal_name: "阪神タイガース",
+      name: '阪神',
+      formal_name: '阪神タイガース',
       ranking: 2,
       league: :central,
       url_id: 5
     },
     {
-      name: "中日",
-      formal_name: "中日ドラゴンズ",
+      name: '中日',
+      formal_name: '中日ドラゴンズ',
       ranking: 3,
       league: :central,
       url_id: 4
     },
     {
-      name: "DeNA",
-      formal_name: "横浜DeNAベイスターズ",
+      name: 'DeNA',
+      formal_name: '横浜DeNAベイスターズ',
       ranking: 4,
       league: :central,
       url_id: 3
     },
     {
-      name: "広島",
-      formal_name: "広島東洋カープ",
+      name: '広島',
+      formal_name: '広島東洋カープ',
       ranking: 5,
       league: :central,
       url_id: 6
     },
     {
-      name: "ヤクルト",
-      formal_name: "東京ヤクルトスワローズ",
+      name: 'ヤクルト',
+      formal_name: '東京ヤクルトスワローズ',
       ranking: 6,
       league: :central,
       url_id: 2

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,90 @@
 # frozen_string_literal: true
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+
+Team.create!(
+  [
+    {
+      name: "ソフトバンク",
+      formal_name: "福岡ソフトバンクホークス",
+      ranking: 1,
+      league: :pacific,
+      url_id: 12
+    },
+    {
+      name: "ロッテ",
+      formal_name: "千葉ロッテマリーンズ",
+      ranking: 2,
+      league: :pacific,
+      url_id: 9
+    },
+    {
+      name: "西武",
+      formal_name: "埼玉西部ライオンズ",
+      ranking: 3,
+      league: :pacific,
+      url_id: 7
+    },
+    {
+      name: "楽天",
+      formal_name: "東北楽天ゴールデンイーグルス",
+      ranking: 4,
+      league: :pacific,
+      url_id: 376
+    },
+    {
+      name: "日本ハム",
+      formal_name: "北海道日本ハムファイターズ",
+      ranking: 5,
+      league: :pacific,
+      url_id: 8
+    },
+    {
+      name: "オリックス",
+      formal_name: "オリックス・バファローズ",
+      ranking: 6,
+      league: :pacific,
+      url_id: 11
+    },
+    {
+      name: "巨人",
+      formal_name: "読売ジャイアンツ",
+      ranking: 1,
+      league: :central,
+      url_id: 1
+    },
+    {
+      name: "阪神",
+      formal_name: "阪神タイガース",
+      ranking: 2,
+      league: :central,
+      url_id: 5
+    },
+    {
+      name: "中日",
+      formal_name: "中日ドラゴンズ",
+      ranking: 3,
+      league: :central,
+      url_id: 4
+    },
+    {
+      name: "DeNA",
+      formal_name: "横浜DeNAベイスターズ",
+      ranking: 4,
+      league: :central,
+      url_id: 3
+    },
+    {
+      name: "広島",
+      formal_name: "広島東洋カープ",
+      ranking: 5,
+      league: :central,
+      url_id: 6
+    },
+    {
+      name: "ヤクルト",
+      formal_name: "東京ヤクルトスワローズ",
+      ranking: 6,
+      league: :central,
+      url_id: 2
+    }
+  ]
+)

--- a/lib/tasks/scrape.rake
+++ b/lib/tasks/scrape.rake
@@ -1,37 +1,24 @@
 # frozen_string_literal: true
 
-TEAMS = { '西武' => 7,
-          'ソフトバンク' => 12,
-          '楽天' => 376,
-          'ロッテ' => 9,
-          '日本ハム' => 8,
-          'オリックス' => 11,
-          '巨人' => 1,
-          'DeNA' => 3,
-          '阪神' => 5,
-          '広島' => 6,
-          '中日' => 4,
-          'ヤクルト' => 2 }.freeze
-
 namespace :scrape do
   desc 'Yahooスポーツから野手の成績を取得'
   task batter_record: :environment do
-    TEAMS.each do |team, number|
-      url = "https://baseball.yahoo.co.jp/npb/teams/#{number}/memberlist?kind=b"
+    Team.all.each do |team|
+      url = "https://baseball.yahoo.co.jp/npb/teams/#{team.url_id}/memberlist?kind=b"
       player_scores = ScoreScraper.new(url).scrape
       player_scores.each do |player_score|
-        BatterScore.new(player_score, team).reflect_in_db
+        BatterScore.new(player_score, team.id).reflect_in_db
       end
     end
   end
 
   desc 'Yahooスポーツから投手の成績を取得'
   task pitcher_record: :environment do
-    TEAMS.each do |team, number|
-      url = "https://baseball.yahoo.co.jp/npb/teams/#{number}/memberlist?kind=p"
+    Team.all.each do |team|
+      url = "https://baseball.yahoo.co.jp/npb/teams/#{team.url_id}/memberlist?kind=p"
       player_scores = ScoreScraper.new(url).scrape
       player_scores.each do |player_score|
-        PitcherScore.new(player_score, team).reflect_in_db
+        PitcherScore.new(player_score, team.id).reflect_in_db
       end
     end
   end


### PR DESCRIPTION
## 目的
現状、チーム名やチームの正式名称などのデータを定数として定義しているため、これをDBに移行して、battersテーブルやpitchersテーブルと関連を持つように変更する。

## 変更点
- Teamsテーブルを作成
- Teamsテーブルにチーム情報を加えるseedデータを作成
- Teamsテーブルとbatters/pitchersテーブルが1対多の関連を持つように変更
- チームの情報を定数として定義していたスクレイピング処理や、データ加工用のクラス、vueコンポーネントをTeamsテーブルを利用したコードに変更

