### PR TITLE
チーム別選手一覧画面にロード中の表示を追加

### DIFF
--- a/app/javascript/AllTeams.vue
+++ b/app/javascript/AllTeams.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" class="row">
+  <div id="app" class="row" v-loading="loading">
     <div class="col s12">
       <h4>チーム別選手一覧</h4>
     </div>
@@ -34,7 +34,7 @@ export default {
       teams: {},
       registeredPlayers: [],
       showTeamPlayersComponent: false,
-      nowLoading: true
+      loading: true
     }
   },
   created() {
@@ -42,6 +42,7 @@ export default {
       this.fetchAllPlayers(),
       this.fetchRegisteredPlayers()
     ]).then(() => {
+      this.loading = false
       this.showTeamPlayersComponent = true
     })
   },


### PR DESCRIPTION
## 目的
チーム別選手一覧画面の表示に多少時間がかかるため、表示までの間にLoadingのデザインを追加する。

## 変更点
- `AllTeams.vue`にLoading処理を追加

[![Image from Gyazo](https://i.gyazo.com/0f3443f93e45ad2b79976285985a79ba.gif)](https://gyazo.com/0f3443f93e45ad2b79976285985a79ba)