### PR TITLE
選手検索機能を実装

### DIFF
--- a/app/javascript/PlayerSearch.vue
+++ b/app/javascript/PlayerSearch.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="row">
-    <div class="col s12">
+    <div class="col s12" id="search-field-title">
       <h4>選手名検索</h4>
       <hr>
     </div>
-    <div class="col s12 center" style="margin: auto; float: none;">
+    <div class="col s6 center m-auto float-none">
       <vue-simple-suggest
         v-model="selected"
         :list="players"
@@ -12,12 +12,13 @@
         value-attribute="id"
         mode="select"
         :filter-by-query="true"
-        style="display: inline-block; width: 400px; margin: 40px 0;">
+        :styles="autoCompleteStyles"
+        class="col s8">
         <template slot="suggestion-item" slot-scope="{ suggestion }">
           <span>{{ suggestion.name }}</span>
         </template>
       </vue-simple-suggest>
-      <el-button type="success" @click="registerProcessing" round style="display: inline-block; margin-left: 16px;">登録</el-button>
+      <el-button type="success" @click="registerProcessing" round class="col s2">登録</el-button>
     </div>
   </div>
 </template>
@@ -31,7 +32,10 @@ export default {
     return {
       teams: [],
       players: [],
-      selected: {}
+      selected: {},
+      autoCompleteStyles: {
+        suggestItem: "left-align"
+      }
     }
   },
   components: {
@@ -89,5 +93,16 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
+.m-auto {
+  margin: auto;
+}
+
+.float-none {
+  float: none;
+}
+
+#search-field-title{
+  margin-bottom: 40px;
+}
 </style>

--- a/app/javascript/PlayerSearch.vue
+++ b/app/javascript/PlayerSearch.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="row">
+    <div class="col s12">
+      <h4>選手名検索</h4>
+      <hr>
+    </div>
+    <div class="col s12 center" style="margin: auto; float: none;">
+      <vue-simple-suggest
+        v-model="selected"
+        :list="players"
+        display-attribute="name"
+        value-attribute="id"
+        mode="select"
+        :filter-by-query="true"
+        style="display: inline-block; width: 400px; margin: 40px 0;">
+        <template slot="suggestion-item" slot-scope="{ suggestion }">
+          <span>{{ suggestion.name }}</span>
+        </template>
+      </vue-simple-suggest>
+      <el-button type="success" @click="registerProcessing" round style="display: inline-block; margin-left: 16px;">登録</el-button>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+import VueSimpleSuggest from 'vue-simple-suggest'
+
+export default {
+  data() {
+    return {
+      teams: [],
+      players: [],
+      selected: {}
+    }
+  },
+  components: {
+    VueSimpleSuggest
+  },
+  created() {
+    Promise.all([
+      this.fetchAllTeams()
+    ]).then(() => {
+      this.disassembleTeams('central')
+      this.disassembleTeams('pacific')
+      this.players = this.players.flat()
+    })
+  },
+  methods: {
+    fetchAllTeams() {
+      return axios.get('/api/v1/players').then(response => this.teams = response.data)
+    },
+    disassembleTeams(league) {
+      const teams = this.teams[`${league}`]
+      for (let dividedTeam of teams) {
+        const batters = dividedTeam['batters'].map(batter => ({...batter, playerType: "batters"}))
+        this.players.push(batters)
+        const pitchers = dividedTeam['pitchers'].map(pitcher => ({...pitcher, playerType: "pitchers"}))
+        this.players.push(pitchers)
+      }
+    },
+    registerProcessing(){
+      this.registerPlayer().then(() => {
+        this.successNotice()
+      }).catch(() => {
+        this.duplicateErrorNotice()
+      }).finally(() => {
+        this.selected = ''
+      })
+    },
+    registerPlayer: async function() {
+      return await axios.post(`/api/v1/favorite_${this.selected['playerType']}`, {player_id: this.selected['id']})
+    },
+    successNotice() {
+      this.$notify({
+        title: '登録完了',
+        message: '選手を登録しました',
+        type: 'success'
+      })
+    },
+    duplicateErrorNotice() {
+      this.$notify({
+        title: '登録エラー',
+        message: 'この選手は既に登録されています',
+        type: 'error'
+      })
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/app/javascript/PlayerSearch.vue
+++ b/app/javascript/PlayerSearch.vue
@@ -57,11 +57,12 @@ export default {
     disassembleTeams(league) {
       const teams = this.teams[`${league}`]
       for (let dividedTeam of teams) {
-        const batters = dividedTeam['batters'].map(batter => ({...batter, playerType: "batters"}))
-        this.players.push(batters)
-        const pitchers = dividedTeam['pitchers'].map(pitcher => ({...pitcher, playerType: "pitchers"}))
-        this.players.push(pitchers)
+        this.players.push(this.addPlayerTypeProperty(dividedTeam['batters'], 'batters'))
+        this.players.push(this.addPlayerTypeProperty(dividedTeam['pitchers'], 'pitchers'))
       }
+    },
+    addPlayerTypeProperty(players, playerType) {
+      return players.map(player => ({...player, playerType: `${playerType}`}))
     },
     registerProcessing(){
       this.registerPlayer().then(() => {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -5,4 +5,5 @@ require("channels")
 
 import '../css/application.css'
 
-import '../all_teams.js'
+import '../all_teams'
+import '../player_search'

--- a/app/javascript/player_search.js
+++ b/app/javascript/player_search.js
@@ -1,0 +1,16 @@
+import Vue from 'vue'
+import PlayerSearch from './PlayerSearch.vue'
+import ElementUI from 'element-ui'
+import 'element-ui/lib/theme-chalk/index.css'
+import 'vue-simple-suggest/dist/styles.css'
+
+Vue.use(ElementUI)
+
+document.addEventListener('turbolinks:load', () => {
+  const playerSearch = document.getElementById('js-player-search')
+  if (playerSearch) {
+    new Vue({
+      render: h => h(PlayerSearch)
+    }).$mount('#js-player-search')
+  }
+})

--- a/app/views/players/index.html.slim
+++ b/app/views/players/index.html.slim
@@ -1,1 +1,2 @@
+#js-player-search
 #js-all-teams

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "turbolinks": "^5.2.0",
     "vue": "^2.6.12",
     "vue-loader": "^15.9.5",
+    "vue-simple-suggest": "^1.10.3",
     "vue-template-compiler": "^2.6.12"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7469,6 +7469,11 @@ vue-loader@^15.9.5:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
+vue-simple-suggest@^1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/vue-simple-suggest/-/vue-simple-suggest-1.10.3.tgz#c3773f06eb4d9d91ee7eabbf799bab45c8dd15d9"
+  integrity sha512-5yBGlVOQ5gvrkuoT6TtdVHLXy507EKN7X8vgXhPJsMbcJFuDTqzd6AFElSK7Bv4UwcKSU/o1OPzD9GBi86VuTQ==
+
 vue-style-loader@^4.1.0:
   version "4.1.2"
   resolved "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz"


### PR DESCRIPTION
## 目的
選手名をサジェスト検索できる検索フォームを作成し、登録ボタンを押すと選手の登録ができるようにする。

## 変更箇所
- `player_search.js`というエントリポイントを作成
- 新たにVueコンポーネント`PlayerSearch.vue`を作成、選手一覧画面にマウント
  - サジェスト検索機能はvue-simple-suggestを使用
  - https://github.com/KazanExpress/vue-simple-suggest


## 未着手の箇所
- 同姓同名の選手の見分けがつかないので、チーム名かチームカラーのアイコンなどを表示する必要がある
- 検索フォームから選手登録をしても、連動してチーム別選手一覧画面の登録ボタンは"解除"に変わらない
  - 検索フォームから選手登録後、チーム別選手一覧の登録ボタンから同一選手を登録しようとすると「この選手は既に登録されています」という警告が表示され、登録ボタンが"解除"に切り替わるため連動の必要性はないと判断

[![Image from Gyazo](https://i.gyazo.com/226d388b0aea6509b154e4930f8c2ff0.gif)](https://gyazo.com/226d388b0aea6509b154e4930f8c2ff0)