### PR TITLE
ユーザーが同一選手を複数登録できないように修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn-debug.log*
 
 # Ignore RubyMine setting files.
 .idea
+.generators

--- a/app/controllers/api/v1/favorite_batters_controller.rb
+++ b/app/controllers/api/v1/favorite_batters_controller.rb
@@ -4,10 +4,10 @@ class Api::V1::FavoriteBattersController < ActionController::API
   before_action :authenticate_user!
 
   def create
-    current_user.favorite_batters.create(batter_id: params[:player_id])
+    current_user.favorite_batters.create!(batter_id: params[:player_id])
   end
 
   def destroy
-    current_user.favorite_batters.find_by(batter_id: params[:player_id]).destroy
+    current_user.favorite_batters.find_by(batter_id: params[:player_id]).destroy!
   end
 end

--- a/app/controllers/api/v1/favorite_pitchers_controller.rb
+++ b/app/controllers/api/v1/favorite_pitchers_controller.rb
@@ -4,10 +4,10 @@ class Api::V1::FavoritePitchersController < ActionController::API
   before_action :authenticate_user!
 
   def create
-    current_user.favorite_pitchers.create(pitcher_id: params[:player_id])
+    current_user.favorite_pitchers.create!(pitcher_id: params[:player_id])
   end
 
   def destroy
-    current_user.favorite_pitchers.find_by(pitcher_id: params[:player_id]).destroy
+    current_user.favorite_pitchers.find_by(pitcher_id: params[:player_id]).destroy!
   end
 end

--- a/app/javascript/RegisterButton.vue
+++ b/app/javascript/RegisterButton.vue
@@ -40,12 +40,16 @@ export default {
   },
   methods: {
     registerProcessing(){
-      this.registerPlayer()
-      this.isRegistered = true
-      this.successNotice()
+      this.registerPlayer().then(() => {
+        this.successNotice()
+      }).catch(() => {
+        this.duplicateErrorNotice()
+      }).finally(() => {
+        this.isRegistered = true
+      })
     },
     registerPlayer: async function() {
-      await axios.post(`/api/v1/favorite_${this.playerType}`, {player_id: this.selectedPlayerId})
+      return await axios.post(`/api/v1/favorite_${this.playerType}`, {player_id: this.selectedPlayerId})
     },
     successNotice() {
       this.$notify({
@@ -54,15 +58,22 @@ export default {
         type: 'success'
       })
     },
+    duplicateErrorNotice() {
+      this.$notify({
+        title: '登録エラー',
+        message: 'この選手は既に登録されています',
+        type: 'error'
+      })
+    },
     releaseProcessing() {
       this.releasePlayer()
       this.isRegistered = false
-      this.deleteNotice()
+      this.releaseNotice()
     },
     releasePlayer: async function() {
       await axios.delete(`/api/v1/favorite_${this.playerType}`, {data: {player_id: this.selectedPlayerId}})
     },
-    deleteNotice() {
+    releaseNotice() {
       this.$notify({
         title: '登録解除',
         message: '選手を登録から解除しました',

--- a/app/models/favorite_batter.rb
+++ b/app/models/favorite_batter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class FavoriteBatter < ApplicationRecord
+  validates :user_id,  uniqueness: { scope: :batter_id }
   belongs_to :user
   belongs_to :batter
 end

--- a/app/models/favorite_pitcher.rb
+++ b/app/models/favorite_pitcher.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class FavoritePitcher < ApplicationRecord
+  validates :user_id,  uniqueness: { scope: :pitcher_id }
   belongs_to :user
   belongs_to :pitcher
 end

--- a/db/migrate/20201224001626_add_unique_index_to_favorite_batters.rb
+++ b/db/migrate/20201224001626_add_unique_index_to_favorite_batters.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToFavoriteBatters < ActiveRecord::Migration[6.0]
+  def change
+    add_index :favorite_batters, [:user_id, :batter_id], unique: true
+  end
+end

--- a/db/migrate/20201224001626_add_unique_index_to_favorite_batters.rb
+++ b/db/migrate/20201224001626_add_unique_index_to_favorite_batters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUniqueIndexToFavoriteBatters < ActiveRecord::Migration[6.0]
   def change
     add_index :favorite_batters, [:user_id, :batter_id], unique: true

--- a/db/migrate/20201224001646_add_unique_index_to_favorite_pitchers.rb
+++ b/db/migrate/20201224001646_add_unique_index_to_favorite_pitchers.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToFavoritePitchers < ActiveRecord::Migration[6.0]
+  def change
+    add_index :favorite_pitchers, [:user_id, :pitcher_id], unique: true
+  end
+end

--- a/db/migrate/20201224001646_add_unique_index_to_favorite_pitchers.rb
+++ b/db/migrate/20201224001646_add_unique_index_to_favorite_pitchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUniqueIndexToFavoritePitchers < ActiveRecord::Migration[6.0]
   def change
     add_index :favorite_pitchers, [:user_id, :pitcher_id], unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_22_012845) do
+ActiveRecord::Schema.define(version: 2020_12_24_001646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 2020_12_22_012845) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["batter_id"], name: "index_favorite_batters_on_batter_id"
+    t.index ["user_id", "batter_id"], name: "index_favorite_batters_on_user_id_and_batter_id", unique: true
     t.index ["user_id"], name: "index_favorite_batters_on_user_id"
   end
 
@@ -51,6 +52,7 @@ ActiveRecord::Schema.define(version: 2020_12_22_012845) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["pitcher_id"], name: "index_favorite_pitchers_on_pitcher_id"
+    t.index ["user_id", "pitcher_id"], name: "index_favorite_pitchers_on_user_id_and_pitcher_id", unique: true
     t.index ["user_id"], name: "index_favorite_pitchers_on_user_id"
   end
 


### PR DESCRIPTION
## 目的
複数のブラウザで同一選手の登録ボタンを押すことで、ユーザーが同一選手を複数人登録できる状態だったため修正を行った。

## 変更点
- favorite_battersとfavorite_pitchersテーブルに、user_idとbatter(pitcher)_idの複合ユニークインデックスを作成
- 登録ボタンコンポーネントに、POSTリクエストが失敗した際のエラーハンドリングを追加

[![Image from Gyazo](https://i.gyazo.com/c92047daaea6f96c1fcd457ba090625b.gif)](https://gyazo.com/c92047daaea6f96c1fcd457ba090625b)