### PR TITLE
players_data_formatter.rbのN+1問題を解消

### DIFF
--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -3,7 +3,9 @@
 class Api::V1::PlayersController < ActionController::API
   def index
     teams = Team.order(:ranking)
-    players_data_formatter = PlayersDataFormatter.new(teams)
+    batters = Batter.select(:id, :number, :name, :team_id)
+    pitchers = Pitcher.select(:id, :number, :name, :team_id)
+    players_data_formatter = PlayersDataFormatter.new(teams, batters, pitchers)
     players_data = players_data_formatter.run
     render json: players_data
   end

--- a/app/models/players_data_formatter.rb
+++ b/app/models/players_data_formatter.rb
@@ -3,20 +3,22 @@
 class PlayersDataFormatter
   attr_reader :all_data
 
-  def initialize(teams)
+  def initialize(teams, batters, pitchers)
     @teams = teams
+    @batters = batters
+    @pitchers = pitchers
   end
 
   def run
     all_data = { central: [], pacific: [] }
     @teams.each do |team|
-      batters = team.batters.select(:id, :number, :name)
-      pitchers = team.pitchers.select(:id, :number, :name)
+      team_batters = divide_by_team(@batters, team)
+      team_pitchers = divide_by_team(@pitchers, team)
       all_data[team.league.to_sym] << {
         name: team.name,
         formal_name: team.formal_name,
-        batters: sort_by_number(batters),
-        pitchers: sort_by_number(pitchers)
+        batters: sort_by_number(team_batters),
+        pitchers: sort_by_number(team_pitchers)
       }
     end
     all_data
@@ -25,5 +27,9 @@ class PlayersDataFormatter
   private
   def sort_by_number(players)
     players.sort_by { |player| player.number.to_i }
+  end
+
+  def divide_by_team(players, team)
+    players.filter { |player| player.team_id == team.id }
   end
 end


### PR DESCRIPTION
## 目的
players_data_formatter.rbの中でSQLを繰り返し処理の中で何度も発行している処理があったため修正。

## 変更箇所
- players_data_formatter内の投手と野手のレコードを取得する処理をplayers_controllerに移動
- team_idを使って選手を各チームに振り分けるdivide_by_teamメソッドを定義