### PR TITLE
battersテーブルに打数と安打数のカラムを追加

### DIFF
--- a/app/models/batter_score.rb
+++ b/app/models/batter_score.rb
@@ -7,6 +7,8 @@ class BatterScore
     @name = scores[2]
     @team_id = team_id
     @batting_average = scores[3]
+    @at_bat = scores[6]
+    @hits = scores[7]
     @home_run = scores[10]
     @runs_batted_in = scores[12]
     @stolen_base = scores[19]
@@ -26,6 +28,8 @@ class BatterScore
                   name: @name,
                   team_id: @team_id,
                   batting_average: @batting_average,
+                  at_bat: @at_bat,
+                  hits: @hits,
                   home_run: @home_run,
                   runs_batted_in: @runs_batted_in,
                   stolen_base: @stolen_base,

--- a/app/views/registered_players/index.html.slim
+++ b/app/views/registered_players/index.html.slim
@@ -49,7 +49,7 @@ div.row
               td
                 = batter.team.name
               td
-                = batter.batting_average
+                = "#{batter.batting_average} (#{batter.at_bat}-#{batter.hits})"
               td
                 = batter.home_run
               td

--- a/db/migrate/20201225003601_add_columns_to_batters.rb
+++ b/db/migrate/20201225003601_add_columns_to_batters.rb
@@ -1,0 +1,6 @@
+class AddColumnsToBatters < ActiveRecord::Migration[6.0]
+  def change
+    add_column :batters, :at_bat, :integer
+    add_column :batters, :hits, :integer
+  end
+end

--- a/db/migrate/20201225003601_add_columns_to_batters.rb
+++ b/db/migrate/20201225003601_add_columns_to_batters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddColumnsToBatters < ActiveRecord::Migration[6.0]
   def change
     add_column :batters, :at_bat, :integer

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_24_001646) do
+ActiveRecord::Schema.define(version: 2020_12_25_003601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,8 @@ ActiveRecord::Schema.define(version: 2020_12_24_001646) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "url"
     t.bigint "team_id"
+    t.integer "at_bat"
+    t.integer "hits"
     t.index ["team_id"], name: "index_batters_on_team_id"
   end
 


### PR DESCRIPTION
## 目的
登録選手の成績表示で、打率の横に（打数-安打数）の表示が必要となるため、battersテーブルに新たにカラムを追加する。

## 変更点
- battersテーブルに`at_bat`と`hits`カラムを追加
- スクレイピングで打数と安打数のデータも取得するように変更
- 登録選手一覧の成績に（打数-安打数）を追加


![image](https://user-images.githubusercontent.com/59789739/103113051-28e6f800-469c-11eb-9afb-d361b4c03ba9.png)


