### PR TITLE
野手・投手の成績のデータ型をStringに統一

### DIFF
--- a/app/javascript/RegisteredBatters.vue
+++ b/app/javascript/RegisteredBatters.vue
@@ -1,9 +1,17 @@
 <template>
   <div id="app">
     <vue-good-table
+      v-if="batters && batters.length"
       @on-selected-rows-change="selectionChanged"
       :columns="columns"
       :rows="batters"
+      :sort-options="{
+        enabled: true,
+        initialSortBy: [
+            {field: 'sort_flag', type: 'desc'},
+            {field: 'at_bat', type: 'desc'}
+        ]
+      }"
       :select-options="{
         enabled: true,
         selectionText: '選手を選択中',
@@ -43,7 +51,8 @@ export default {
         {
           label: '背番号',
           field: 'number',
-          type: 'number'
+          type: 'number',
+          sortable: false
         },
         {
           label: '選手名',
@@ -130,6 +139,11 @@ export default {
           label: '失策',
           field: 'error',
           type: 'number'
+        },
+        {
+          field: 'sort_flag',
+          type: 'number',
+          hidden: 'true'
         }
       ]
     }

--- a/app/javascript/RegisteredPitchers.vue
+++ b/app/javascript/RegisteredPitchers.vue
@@ -1,9 +1,17 @@
 <template>
   <div id="app">
     <vue-good-table
+      v-if="pitchers && pitchers.length"
       @on-selected-rows-change="selectionChanged"
       :columns="columns"
       :rows="pitchers"
+      :sort-options="{
+        enabled: true,
+        initialSortBy: [
+            {field: 'sort_flag', type: 'desc'},
+            {field: 'innings_pitched', type: 'desc'}
+        ]
+      }"
       :select-options="{
         enabled: true,
         selectionText: '選手を選択中',
@@ -43,7 +51,8 @@ export default {
         {
           label: '背番号',
           field: 'number',
-          type: 'number'
+          type: 'number',
+          sortable: false
         },
         {
           label: '選手名',
@@ -117,6 +126,11 @@ export default {
           label: 'WHIP',
           field: 'walks_and_hits_per_innings_pitched',
           type: 'number'
+        },
+        {
+          field: 'sort_flag',
+          type: 'number',
+          hidden: true
         }
       ]
     }

--- a/app/models/batter_score.rb
+++ b/app/models/batter_score.rb
@@ -7,6 +7,7 @@ class BatterScore
     @name = scores[2]
     @team_id = team_id
     @batting_average = scores[3]
+    @plate_appearance = scores[5]
     @at_bat = scores[6]
     @hits = scores[7]
     @home_run = scores[10]
@@ -23,11 +24,12 @@ class BatterScore
 
   def reflect_in_db
     batter = Batter.find_or_initialize_by(url: @url)
-    batter.update(number: @number,
+    batter.update!(number: @number,
                   url: @url,
                   name: @name,
                   team_id: @team_id,
                   batting_average: @batting_average,
+                  plate_appearance: @plate_appearance,
                   at_bat: @at_bat,
                   hits: @hits,
                   home_run: @home_run,

--- a/app/models/pitcher_score.rb
+++ b/app/models/pitcher_score.rb
@@ -21,7 +21,7 @@ class PitcherScore
 
   def reflect_in_db
     pitcher = Pitcher.find_or_initialize_by(url: @url)
-    pitcher.update(number: @number,
+    pitcher.update!(number: @number,
                    url: @url,
                    name: @name,
                    team_id: @team_id,

--- a/app/views/api/v1/registered_players/index.json.jbuilder
+++ b/app/views/api/v1/registered_players/index.json.jbuilder
@@ -7,6 +7,7 @@ json.batters do
                   :walks, :hit_by_pitch, :scoring_position_batting_average, :strikeout, :error
     json.batter_id batter.id
     json.team batter.team.name
+    batter.plate_appearance == '-' ? json.sort_flag(0) : json.sort_flag(1)
   end
 end
 
@@ -17,5 +18,6 @@ json.pitchers do
                   :strikeout_to_walk_ratio, :walks_and_hits_per_innings_pitched
     json.pitcher_id pitcher.id
     json.team pitcher.team.name
+    pitcher.pitched == '-' ? json.sort_flag(0) : json.sort_flag(1)
   end
 end

--- a/db/migrate/20210105064536_change_data_type_columns_to_batters.rb
+++ b/db/migrate/20210105064536_change_data_type_columns_to_batters.rb
@@ -1,0 +1,25 @@
+class ChangeDataTypeColumnsToBatters < ActiveRecord::Migration[6.0]
+  def up
+    change_column :batters, :home_run, :string
+    change_column :batters, :runs_batted_in, :string
+    change_column :batters, :stolen_base, :string
+    change_column :batters, :walks, :string
+    change_column :batters, :hit_by_pitch, :string
+    change_column :batters, :strikeout, :string
+    change_column :batters, :error, :string
+    change_column :batters, :at_bat, :string
+    change_column :batters, :hits, :string
+  end
+
+  def down
+    change_column :batters, :home_run, :integer
+    change_column :batters, :runs_batted_in, :integer
+    change_column :batters, :stolen_base, :integer
+    change_column :batters, :walks, :integer
+    change_column :batters, :hit_by_pitch, :integer
+    change_column :batters, :strikeout, :integer
+    change_column :batters, :error, :integer
+    change_column :batters, :at_bat, :integer
+    change_column :batters, :hits, :integer 
+  end
+end

--- a/db/migrate/20210105064536_change_data_type_columns_to_batters.rb
+++ b/db/migrate/20210105064536_change_data_type_columns_to_batters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeDataTypeColumnsToBatters < ActiveRecord::Migration[6.0]
   def up
     change_column :batters, :home_run, :string
@@ -20,6 +22,6 @@ class ChangeDataTypeColumnsToBatters < ActiveRecord::Migration[6.0]
     change_column :batters, :strikeout, :integer
     change_column :batters, :error, :integer
     change_column :batters, :at_bat, :integer
-    change_column :batters, :hits, :integer 
+    change_column :batters, :hits, :integer
   end
 end

--- a/db/migrate/20210105064545_change_data_type_columns_to_pitchers.rb
+++ b/db/migrate/20210105064545_change_data_type_columns_to_pitchers.rb
@@ -1,0 +1,27 @@
+class ChangeDataTypeColumnsToPitchers < ActiveRecord::Migration[6.0]
+  def up
+    change_column :pitchers, :earned_run_average,:string
+    change_column :pitchers, :win,:string
+    change_column :pitchers, :lose,:string
+    change_column :pitchers, :strikeout,:string
+    change_column :pitchers, :pitched,:string
+    change_column :pitchers, :number_of_save,:string
+    change_column :pitchers, :hold_point,:string
+    change_column :pitchers, :strikeouts_per_nine_innings,:string
+    change_column :pitchers, :strikeout_to_walk_ratio,:string
+    change_column :pitchers, :walks_and_hits_per_innings_pitched,:string
+  end
+  
+  def down
+    change_column :pitchers, :earned_run_average,:float
+    change_column :pitchers, :win,:integer
+    change_column :pitchers, :lose,:integer
+    change_column :pitchers, :strikeout,:integer
+    change_column :pitchers, :pitched,:integer
+    change_column :pitchers, :number_of_save,:integer
+    change_column :pitchers, :hold_point,:integer
+    change_column :pitchers, :strikeouts_per_nine_innings,:float
+    change_column :pitchers, :strikeout_to_walk_ratio,:float
+    change_column :pitchers, :walks_and_hits_per_innings_pitched,:float
+  end
+end

--- a/db/migrate/20210105064545_change_data_type_columns_to_pitchers.rb
+++ b/db/migrate/20210105064545_change_data_type_columns_to_pitchers.rb
@@ -1,27 +1,29 @@
+# frozen_string_literal: true
+
 class ChangeDataTypeColumnsToPitchers < ActiveRecord::Migration[6.0]
   def up
-    change_column :pitchers, :earned_run_average,:string
-    change_column :pitchers, :win,:string
-    change_column :pitchers, :lose,:string
-    change_column :pitchers, :strikeout,:string
-    change_column :pitchers, :pitched,:string
-    change_column :pitchers, :number_of_save,:string
-    change_column :pitchers, :hold_point,:string
-    change_column :pitchers, :strikeouts_per_nine_innings,:string
-    change_column :pitchers, :strikeout_to_walk_ratio,:string
-    change_column :pitchers, :walks_and_hits_per_innings_pitched,:string
+    change_column :pitchers, :earned_run_average, :string
+    change_column :pitchers, :win, :string
+    change_column :pitchers, :lose, :string
+    change_column :pitchers, :strikeout, :string
+    change_column :pitchers, :pitched, :string
+    change_column :pitchers, :number_of_save, :string
+    change_column :pitchers, :hold_point, :string
+    change_column :pitchers, :strikeouts_per_nine_innings, :string
+    change_column :pitchers, :strikeout_to_walk_ratio, :string
+    change_column :pitchers, :walks_and_hits_per_innings_pitched, :string
   end
-  
+
   def down
-    change_column :pitchers, :earned_run_average,:float
-    change_column :pitchers, :win,:integer
-    change_column :pitchers, :lose,:integer
-    change_column :pitchers, :strikeout,:integer
-    change_column :pitchers, :pitched,:integer
-    change_column :pitchers, :number_of_save,:integer
-    change_column :pitchers, :hold_point,:integer
-    change_column :pitchers, :strikeouts_per_nine_innings,:float
-    change_column :pitchers, :strikeout_to_walk_ratio,:float
-    change_column :pitchers, :walks_and_hits_per_innings_pitched,:float
+    change_column :pitchers, :earned_run_average, :float
+    change_column :pitchers, :win, :integer
+    change_column :pitchers, :lose, :integer
+    change_column :pitchers, :strikeout, :integer
+    change_column :pitchers, :pitched, :integer
+    change_column :pitchers, :number_of_save, :integer
+    change_column :pitchers, :hold_point, :integer
+    change_column :pitchers, :strikeouts_per_nine_innings, :float
+    change_column :pitchers, :strikeout_to_walk_ratio, :float
+    change_column :pitchers, :walks_and_hits_per_innings_pitched, :float
   end
 end

--- a/db/migrate/20210105070138_add_plate_appearance_to_batters.rb
+++ b/db/migrate/20210105070138_add_plate_appearance_to_batters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPlateAppearanceToBatters < ActiveRecord::Migration[6.0]
   def change
     add_column :batters, :plate_appearance, :string

--- a/db/migrate/20210105070138_add_plate_appearance_to_batters.rb
+++ b/db/migrate/20210105070138_add_plate_appearance_to_batters.rb
@@ -1,0 +1,5 @@
+class AddPlateAppearanceToBatters < ActiveRecord::Migration[6.0]
+  def change
+    add_column :batters, :plate_appearance, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_05_064545) do
+ActiveRecord::Schema.define(version: 2021_01_05_070138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2021_01_05_064545) do
     t.bigint "team_id"
     t.string "at_bat"
     t.string "hits"
+    t.string "plate_appearance"
     t.index ["team_id"], name: "index_batters_on_team_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_25_003601) do
+ActiveRecord::Schema.define(version: 2021_01_05_064545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,22 +19,22 @@ ActiveRecord::Schema.define(version: 2020_12_25_003601) do
     t.string "number"
     t.string "name"
     t.string "batting_average"
-    t.integer "home_run"
-    t.integer "runs_batted_in"
-    t.integer "stolen_base"
+    t.string "home_run"
+    t.string "runs_batted_in"
+    t.string "stolen_base"
     t.string "on_base_percentage"
     t.string "on_base_plus_slugging"
-    t.integer "walks"
-    t.integer "hit_by_pitch"
+    t.string "walks"
+    t.string "hit_by_pitch"
     t.string "scoring_position_batting_average"
-    t.integer "strikeout"
-    t.integer "error"
+    t.string "strikeout"
+    t.string "error"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "url"
     t.bigint "team_id"
-    t.integer "at_bat"
-    t.integer "hits"
+    t.string "at_bat"
+    t.string "hits"
     t.index ["team_id"], name: "index_batters_on_team_id"
   end
 
@@ -61,17 +61,17 @@ ActiveRecord::Schema.define(version: 2020_12_25_003601) do
   create_table "pitchers", force: :cascade do |t|
     t.string "number"
     t.string "name"
-    t.float "earned_run_average"
-    t.integer "win"
-    t.integer "lose"
-    t.integer "strikeout"
+    t.string "earned_run_average"
+    t.string "win"
+    t.string "lose"
+    t.string "strikeout"
     t.string "innings_pitched"
-    t.integer "pitched"
-    t.integer "number_of_save"
-    t.integer "hold_point"
-    t.float "strikeouts_per_nine_innings"
-    t.float "strikeout_to_walk_ratio"
-    t.float "walks_and_hits_per_innings_pitched"
+    t.string "pitched"
+    t.string "number_of_save"
+    t.string "hold_point"
+    t.string "strikeouts_per_nine_innings"
+    t.string "strikeout_to_walk_ratio"
+    t.string "walks_and_hits_per_innings_pitched"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "url"


### PR DESCRIPTION
## 目的
野手・投手の成績の型がバラバラになっていたため、打率の表示を崩さず、かつデータなしを`-`で表現できるstring型に統一する。

## 変更点
- 野手・投手の成績データの型をstringに変更
- `-`が存在していても正しくソートが行えるようにDB及びVueのテーブルにカラムを追加*

## `-`のソートに関して
成績データをstring型に統一するにあたって、データなしを表す`-`が混在することでソートがうまく行えない不具合が発生した。
その不具合を解消するために、野手では打席に立っていない選手、投手では登板のない選手を判断するためのフラグを用意し、データのない選手がソート時に下部に固定されるように実装した。

## 注意点
- 打席に立っていながらデータの無い成績が存在する選手（例：得点圏の打数がない場合）や、打席には立っていないが記録されている成績がある選手（例：打席に立たず盗塁・失策を記録している場合）にソートがうまく行えないことがある。

[![Image from Gyazo](https://i.gyazo.com/e64cb36209ab82971d2adc89e08f7030.gif)](https://gyazo.com/e64cb36209ab82971d2adc89e08f7030)
