### PR TITLE
データの更新時間を表示する

### DIFF
--- a/app/controllers/registered_players_controller.rb
+++ b/app/controllers/registered_players_controller.rb
@@ -6,5 +6,6 @@ class RegisteredPlayersController < ApplicationController
   def index
     @favorite_batters = current_user.favorite_batters.all
     @favorite_pitchers = current_user.favorite_pitchers.all
+    @data_update_at = ScrapingLog.last.updated_at
   end
 end

--- a/app/models/scraping_log.rb
+++ b/app/models/scraping_log.rb
@@ -1,0 +1,2 @@
+class ScrapingLog < ApplicationRecord
+end

--- a/app/models/scraping_log.rb
+++ b/app/models/scraping_log.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ScrapingLog < ApplicationRecord
 end

--- a/app/views/registered_players/index.html.slim
+++ b/app/views/registered_players/index.html.slim
@@ -1,1 +1,3 @@
+span.right
+  = "#{l @data_update_at}更新"
 #js-registered-players

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ module ProspectsWatcher
       g.assets false
     end
     config.i18n.default_locale = :ja
+    config.time_zone = 'Asia/Tokyo'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,7 @@
 ja:
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M"
   activerecord:
     models:
       batter: 野手

--- a/db/migrate/20210106004245_create_scraping_logs.rb
+++ b/db/migrate/20210106004245_create_scraping_logs.rb
@@ -1,0 +1,7 @@
+class CreateScrapingLogs < ActiveRecord::Migration[6.0]
+  def change
+    create_table :scraping_logs do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210106004245_create_scraping_logs.rb
+++ b/db/migrate/20210106004245_create_scraping_logs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateScrapingLogs < ActiveRecord::Migration[6.0]
   def change
     create_table :scraping_logs do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_05_070138) do
+ActiveRecord::Schema.define(version: 2021_01_06_004245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,11 @@ ActiveRecord::Schema.define(version: 2021_01_05_070138) do
     t.string "url"
     t.bigint "team_id"
     t.index ["team_id"], name: "index_pitchers_on_team_id"
+  end
+
+  create_table "scraping_logs", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "teams", force: :cascade do |t|

--- a/lib/tasks/scrape.rake
+++ b/lib/tasks/scrape.rake
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 namespace :scrape do
+  desc '選手成績を取得'
+  task player_record: :environment do
+    Rake::Task['scrape:batter_record'].invoke
+    Rake::Task['scrape:pitcher_record'].invoke
+    ScrapingLog.create!
+  end
+
   desc 'Yahooスポーツから野手の成績を取得'
   task batter_record: :environment do
     Team.all.each do |team|


### PR DESCRIPTION
## 目的
表示されているデータの更新がいつ行われたかユーザーが確認できるように、スクレイピングを実行した時間を登録選手一覧画面に表示する。

## 変更点
- スクレイピングを実行した時間を記録するScrapingLogテーブルを作成
- 野手と投手のスクレイピングタスクを一度に実行し、実行時間をScrapingLogテーブルに格納するタスクを新たに定義
- タイムゾーンを東京に設定
- 時間表示のフォーマットを追加
- 登録選手一覧画面に更新時間を表示

## 注意点
- スクレイピングの例外処理は未実装

![image](https://user-images.githubusercontent.com/59789739/103720910-caad0400-500f-11eb-845c-d68ab9358620.png)
