### PR TITLE
選手比較機能の追加

### DIFF
--- a/app/javascript/CompareBatterScoreTable.vue
+++ b/app/javascript/CompareBatterScoreTable.vue
@@ -63,7 +63,7 @@ export default {
     }
   },
   mounted() {
-    [this.playerX, this.playerY] = this.checkedPlayers
+    [this.playerY, this.playerX] = this.checkedPlayers
   },
   methods: {
     closeModal() {

--- a/app/javascript/CompareBatterScoreTable.vue
+++ b/app/javascript/CompareBatterScoreTable.vue
@@ -1,9 +1,9 @@
 <template>
   <v-container id="app">
-    <h4>選手比較</h4>
+    <v-btn icon fab small @click="closeModal()"><v-icon>mdi-close-circle</v-icon></v-btn>
     <table>
       <tr>
-        <td>{{playerX.name}}</td><th>選手名</th><td>{{playerY.name}}</td>
+        <td :class="['player-name', playerX['english_team_name']]">{{playerX.name}}</td><th>選手名</th><td :class="['player-name', playerY['english_team_name']]">{{playerY.name}}</td>
       </tr>
       <tr>
         <td :class="{ emphasis: atBatX() }">{{playerX['at_bat']}}</td><th>打数</th><td :class="{ emphasis: atBatY() }">{{playerY['at_bat']}}</td>
@@ -66,6 +66,9 @@ export default {
     [this.playerX, this.playerY] = this.checkedPlayers
   },
   methods: {
+    closeModal() {
+      this.$emit('close-modal')
+    },
     atBatX() {
       return parseInt(this.playerX['at_bat']) >= parseInt(this.playerY['at_bat'])
     },
@@ -149,8 +152,42 @@ export default {
 </script>
 
 <style scoped>
-table > tr > td,th {
+.v-container {
+  position: relative;
+}
+
+table {
+  width: 80%;
+  margin: auto;
+  border: 1px solid #dcdfe6;
+  border-collapse: collapse
+}
+
+table th {
+  color: #606266;
+  vertical-align: bottom;
+  border-bottom: 1px solid #dcdfe6;
+  background: linear-gradient(#f4f5f8,#f1f3f6);
+  padding: 10px 0;
   text-align: center;
+}
+
+table td {
+  padding: 10px 0;
+  text-align: center;
+  width: 35%;
+}
+
+.player-name {
+  font-weight: bold;
+  font-size: 1.2rem;
+  background: linear-gradient(#f4f5f8,#f1f3f6);
+}
+
+.v-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 .emphasis {
@@ -158,4 +195,75 @@ table > tr > td,th {
   color: red;
 }
 
+.hawks {
+  content: '';
+  border-bottom: thick solid #FEA409;
+  padding-bottom: 4px;
+}
+
+.marines {
+  content: '';
+  border-bottom: thick solid #6E6E6E;
+  padding-bottom: 4px;
+}
+
+.lions {
+  content: '';
+  border-bottom: thick solid #192546;
+  padding-bottom: 4px;
+}
+
+.eagles {
+  content: '';
+  border-bottom: thick solid #7F001E;
+  padding-bottom: 4px;
+}
+
+.fighters {
+  content: '';
+  border-bottom: thick solid #285A8A;
+  padding-bottom: 4px;
+}
+
+.buffaloes {
+  content: '';
+  border-bottom: thick solid #34328A;
+  padding-bottom: 4px;
+}
+
+.giants {
+  content: '';
+  border-bottom: thick solid #E96D06;
+  padding-bottom: 4px;
+}
+
+.tigers {
+  content: '';
+  border-bottom: thick solid #FED80C;
+  padding-bottom: 4px;
+}
+
+.dragons {
+  content: '';
+  border-bottom: thick solid #113C7C;
+  padding-bottom: 4px;
+}
+
+.baystars {
+  content: '';
+  border-bottom: thick solid #1182D8;
+  padding-bottom: 4px;
+}
+
+.carp {
+  content: '';
+  border-bottom: thick solid #C70019;
+  padding-bottom: 4px;
+}
+
+.swallows {
+  content: '';
+  border-bottom: thick solid #1A753E;
+  padding-bottom: 4px;
+}
 </style>

--- a/app/javascript/CompareBatterScoreTable.vue
+++ b/app/javascript/CompareBatterScoreTable.vue
@@ -3,46 +3,94 @@
     <v-btn icon fab small @click="closeModal()"><v-icon>mdi-close-circle</v-icon></v-btn>
     <table>
       <tr>
-        <td :class="['player-name', playerX['english_team_name']]">{{playerX.name}}</td><th>選手名</th><td :class="['player-name', playerY['english_team_name']]">{{playerY.name}}</td>
+        <td :class="['player-name', playerX['english_team_name']]">{{playerX.name}}</td>
+        <th>選手名</th>
+        <td :class="['player-name', playerY['english_team_name']]">{{playerY.name}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: atBatX() }">{{playerX['at_bat']}}</td><th>打数</th><td :class="{ emphasis: atBatY() }">{{playerY['at_bat']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['at_bat'], playerY['at_bat']) }">{{playerX['at_bat']}}</td>
+        <th>打数</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['at_bat'], playerX['at_bat']) }">{{playerY['at_bat']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: hitsX() }">{{playerX['hits']}}</td><th>安打</th><td :class="{ emphasis: hitsY() }">{{playerY['hits']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['hits'], playerY['hits']) }">{{playerX['hits']}}</td>
+        <th>安打</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['hits'], playerX['hits']) }">{{playerY['hits']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: battingAverageX() }">{{playerX['batting_average']}}</td><th>打率</th><td :class="{ emphasis: battingAverageY() }">{{playerY['batting_average']}}</td>
+        <td :class="{ emphasis: isEmphasisFloat(playerX['batting_average'], playerY['batting_average']) }">
+          {{playerX['batting_average']}}
+        </td>
+        <th>打率</th>
+        <td :class="{ emphasis: isEmphasisFloat(playerY['batting_average'], playerX['batting_average']) }">
+          {{playerY['batting_average']}}
+        </td>
       </tr>
       <tr>
-        <td :class="{ emphasis: homeRunX() }">{{playerX['home_run']}}</td><th>HR</th><td :class="{ emphasis: homeRunY() }">{{playerY['home_run']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['home_run'], playerY['home_run']) }">{{playerX['home_run']}}</td>
+        <th>HR</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['home_run'], playerX['home_run']) }">{{playerY['home_run']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: runsBattedInX() }">{{playerX['runs_batted_in']}}</td><th>打点</th><td :class="{ emphasis: runsBattedInY() }">{{playerY['runs_batted_in']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['runs_batted_in'], playerY['runs_batted_in']) }">
+          {{playerX['runs_batted_in']}}
+        </td>
+        <th>打点</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['runs_batted_in'], playerX['runs_batted_in']) }">
+          {{playerY['runs_batted_in']}}
+        </td>
       </tr>
       <tr>
-        <td :class="{ emphasis: stolenBaseX() }">{{playerX['stolen_base']}}</td><th>盗塁</th><td :class="{ emphasis: stolenBaseY() }">{{playerY['stolen_base']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['stolen_base'], playerY['stolen_base']) }">{{playerX['stolen_base']}}</td>
+        <th>盗塁</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['stolen_base'], playerX['stolen_base']) }">{{playerY['stolen_base']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: onBasePercentageX() }">{{playerX['on_base_percentage']}}</td><th>出塁率</th><td :class="{ emphasis: onBasePercentageY() }">{{playerY['on_base_percentage']}}</td>
+        <td :class="{ emphasis: isEmphasisFloat(playerX['on_base_percentage'], playerY['on_base_percentage']) }">
+          {{playerX['on_base_percentage']}}
+        </td>
+        <th>出塁率</th>
+        <td :class="{ emphasis: isEmphasisFloat(playerY['on_base_percentage'], playerX['on_base_percentage']) }">
+          {{playerY['on_base_percentage']}}
+        </td>
       </tr>
       <tr>
-        <td :class="{ emphasis: onBasePlusSluggingX() }">{{playerX['on_base_plus_slugging']}}</td><th>OPS</th><td :class="{ emphasis: onBasePlusSluggingY() }">{{playerY['on_base_plus_slugging']}}</td>
+        <td :class="{ emphasis: isEmphasisFloat(playerX['on_base_plus_slugging'], playerY['on_base_plus_slugging']) }">
+          {{playerX['on_base_plus_slugging']}}
+        </td>
+        <th>OPS</th>
+        <td :class="{ emphasis: isEmphasisFloat(playerY['on_base_plus_slugging'], playerX['on_base_plus_slugging']) }">
+          {{playerY['on_base_plus_slugging']}}
+        </td>
       </tr>
       <tr>
-        <td :class="{ emphasis: walksX() }">{{playerX['walks']}}</td><th>四球</th><td :class="{ emphasis: walksY() }">{{playerY['walks']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['walks'], playerY['walks']) }">{{playerX['walks']}}</td>
+        <th>四球</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['walks'], playerX['walks']) }">{{playerY['walks']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: hitByPitchX() }">{{playerX['hit_by_pitch']}}</td><th>死球</th><td :class="{ emphasis: hitByPitchY() }">{{playerY['hit_by_pitch']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['hit_by_pitch'], playerY['hit_by_pitch']) }">{{playerX['hit_by_pitch']}}</td>
+        <th>死球</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['hit_by_pitch'], playerX['hit_by_pitch']) }">{{playerY['hit_by_pitch']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: scoringPositionBattingAverageX() }">{{playerX['scoring_position_batting_average']}}</td><th>得点圏</th><td :class="{ emphasis: scoringPositionBattingAverageY() }">{{playerY['scoring_position_batting_average']}}</td>
+        <td :class="{ emphasis: isEmphasisFloat(playerX['scoring_position_batting_average'], playerY['scoring_position_batting_average']) }">
+          {{playerX['scoring_position_batting_average']}}
+        </td>
+        <th>得点圏</th>
+        <td :class="{ emphasis: isEmphasisFloat(playerY['scoring_position_batting_average'], playerX['scoring_position_batting_average']) }">
+          {{playerY['scoring_position_batting_average']}}
+        </td>
       </tr>
       <tr>
-        <td :class="{ emphasis: strikeoutX() }">{{playerX['strikeout']}}</td><th>三振</th><td :class="{ emphasis: strikeoutY() }">{{playerY['strikeout']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerY['strikeout'], playerX['strikeout']) }">{{playerX['strikeout']}}</td>
+        <th>三振</th>
+        <td :class="{ emphasis: isEmphasisInt(playerX['strikeout'], playerY['strikeout']) }">{{playerY['strikeout']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: errorX() }">{{playerX['error']}}</td><th>失策</th><td :class="{ emphasis: errorY() }">{{playerY['error']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerY['error'], playerX['error']) }">{{playerX['error']}}</td>
+        <th>失策</th>
+        <td :class="{ emphasis: isEmphasisInt(playerX['error'], playerY['error']) }">{{playerY['error']}}</td>
       </tr>
     </table>
   </v-container>
@@ -69,83 +117,11 @@ export default {
     closeModal() {
       this.$emit('close-modal')
     },
-    atBatX() {
-      return parseInt(this.playerX['at_bat']) >= parseInt(this.playerY['at_bat'])
+    isEmphasisInt(playerScoreBefore, playerScoreAfter) {
+      return parseInt(playerScoreBefore) >= parseInt(playerScoreAfter)
     },
-    atBatY() {
-      return parseInt(this.playerX['at_bat']) <= parseInt(this.playerY['at_bat'])
-    },
-    hitsX() {
-      return parseInt(this.playerX['hits']) >= parseInt(this.playerY['hits'])
-    },
-    hitsY() {
-      return parseInt(this.playerX['hits']) <= parseInt(this.playerY['hits'])
-    },
-    battingAverageX() {
-      return parseFloat(this.playerX['batting_average']) >= parseFloat(this.playerY['batting_average'])
-    },
-    battingAverageY() {
-      return parseFloat(this.playerX['batting_average']) <= parseFloat(this.playerY['batting_average'])
-    },
-    homeRunX() {
-      return parseInt(this.playerX['home_run']) >= parseInt(this.playerY['home_run'])
-    },
-    homeRunY() {
-      return parseInt(this.playerX['home_run']) <= parseInt(this.playerY['home_run'])
-    },
-    runsBattedInX() {
-      return parseInt(this.playerX['runs_batted_in']) >= parseInt(this.playerY['runs_batted_in'])
-    },
-    runsBattedInY() {
-      return parseInt(this.playerX['runs_batted_in']) <= parseInt(this.playerY['runs_batted_in'])
-    },
-    stolenBaseX() {
-      return parseInt(this.playerX['stolen_base']) >= parseInt(this.playerY['stolen_base'])
-    },
-    stolenBaseY() {
-      return parseInt(this.playerX['stolen_base']) <= parseInt(this.playerY['stolen_base'])
-    },
-    onBasePercentageX() {
-      return parseFloat(this.playerX['on_base_percentage']) >= parseFloat(this.playerY['on_base_percentage'])
-    },
-    onBasePercentageY() {
-      return parseFloat(this.playerX['on_base_percentage']) <= parseFloat(this.playerY['on_base_percentage'])
-    },
-    onBasePlusSluggingX() {
-      return parseFloat(this.playerX['on_base_plus_slugging']) >= parseFloat(this.playerY['on_base_plus_slugging'])
-    },
-    onBasePlusSluggingY() {
-      return parseFloat(this.playerX['on_base_plus_slugging']) <= parseFloat(this.playerY['on_base_plus_slugging'])
-    },
-    walksX() {
-      return parseInt(this.playerX['walks']) >= parseInt(this.playerY['walks'])
-    },
-    walksY() {
-      return parseInt(this.playerX['walks']) <= parseInt(this.playerY['walks'])
-    },
-    hitByPitchX() {
-      return parseInt(this.playerX['hit_by_pitch']) >= parseInt(this.playerY['hit_by_pitch'])
-    },
-    hitByPitchY() {
-      return parseInt(this.playerX['hit_by_pitch']) <= parseInt(this.playerY['hit_by_pitch'])
-    },
-    scoringPositionBattingAverageX() {
-      return parseFloat(this.playerX['scoring_position_batting_average']) >= parseFloat(this.playerY['scoring_position_batting_average'])
-    },
-    scoringPositionBattingAverageY() {
-      return parseFloat(this.playerX['scoring_position_batting_average']) <= parseFloat(this.playerY['scoring_position_batting_average'])
-    },
-    strikeoutX() {
-      return parseInt(this.playerX['strikeout']) <= parseInt(this.playerY['strikeout'])
-    },
-    strikeoutY() {
-      return parseInt(this.playerX['strikeout']) >= parseInt(this.playerY['strikeout'])
-    },
-    errorX() {
-      return parseInt(this.playerX['error']) <= parseInt(this.playerY['error'])
-    },
-    errorY() {
-      return parseInt(this.playerX['error']) >= parseInt(this.playerY['error'])
+    isEmphasisFloat(playerScoreBefore, playerScoreAfter) {
+      return parseFloat(playerScoreBefore) >= parseFloat(playerScoreAfter)
     }
   }
 }

--- a/app/javascript/CompareBatterScoreTable.vue
+++ b/app/javascript/CompareBatterScoreTable.vue
@@ -1,0 +1,161 @@
+<template>
+  <v-container id="app">
+    <h4>選手比較</h4>
+    <table>
+      <tr>
+        <td>{{playerX.name}}</td><th>選手名</th><td>{{playerY.name}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: atBatX() }">{{playerX['at_bat']}}</td><th>打数</th><td :class="{ emphasis: atBatY() }">{{playerY['at_bat']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: hitsX() }">{{playerX['hits']}}</td><th>安打</th><td :class="{ emphasis: hitsY() }">{{playerY['hits']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: battingAverageX() }">{{playerX['batting_average']}}</td><th>打率</th><td :class="{ emphasis: battingAverageY() }">{{playerY['batting_average']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: homeRunX() }">{{playerX['home_run']}}</td><th>HR</th><td :class="{ emphasis: homeRunY() }">{{playerY['home_run']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: runsBattedInX() }">{{playerX['runs_batted_in']}}</td><th>打点</th><td :class="{ emphasis: runsBattedInY() }">{{playerY['runs_batted_in']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: stolenBaseX() }">{{playerX['stolen_base']}}</td><th>盗塁</th><td :class="{ emphasis: stolenBaseY() }">{{playerY['stolen_base']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: onBasePercentageX() }">{{playerX['on_base_percentage']}}</td><th>出塁率</th><td :class="{ emphasis: onBasePercentageY() }">{{playerY['on_base_percentage']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: onBasePlusSluggingX() }">{{playerX['on_base_plus_slugging']}}</td><th>OPS</th><td :class="{ emphasis: onBasePlusSluggingY() }">{{playerY['on_base_plus_slugging']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: walksX() }">{{playerX['walks']}}</td><th>四球</th><td :class="{ emphasis: walksY() }">{{playerY['walks']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: hitByPitchX() }">{{playerX['hit_by_pitch']}}</td><th>死球</th><td :class="{ emphasis: hitByPitchY() }">{{playerY['hit_by_pitch']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: scoringPositionBattingAverageX() }">{{playerX['scoring_position_batting_average']}}</td><th>得点圏</th><td :class="{ emphasis: scoringPositionBattingAverageY() }">{{playerY['scoring_position_batting_average']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: strikeoutX() }">{{playerX['strikeout']}}</td><th>三振</th><td :class="{ emphasis: strikeoutY() }">{{playerY['strikeout']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: errorX() }">{{playerX['error']}}</td><th>失策</th><td :class="{ emphasis: errorY() }">{{playerY['error']}}</td>
+      </tr>
+    </table>
+  </v-container>
+</template>
+
+<script>
+export default {
+  props: {
+    checkedPlayers: {
+      type: Array,
+      require: true
+    }
+  },
+  data: function () {
+    return {
+      playerX: null,
+      playerY: null
+    }
+  },
+  mounted() {
+    [this.playerX, this.playerY] = this.checkedPlayers
+  },
+  methods: {
+    atBatX() {
+      return parseInt(this.playerX['at_bat']) >= parseInt(this.playerY['at_bat'])
+    },
+    atBatY() {
+      return parseInt(this.playerX['at_bat']) <= parseInt(this.playerY['at_bat'])
+    },
+    hitsX() {
+      return parseInt(this.playerX['hits']) >= parseInt(this.playerY['hits'])
+    },
+    hitsY() {
+      return parseInt(this.playerX['hits']) <= parseInt(this.playerY['hits'])
+    },
+    battingAverageX() {
+      return parseFloat(this.playerX['batting_average']) >= parseFloat(this.playerY['batting_average'])
+    },
+    battingAverageY() {
+      return parseFloat(this.playerX['batting_average']) <= parseFloat(this.playerY['batting_average'])
+    },
+    homeRunX() {
+      return parseInt(this.playerX['home_run']) >= parseInt(this.playerY['home_run'])
+    },
+    homeRunY() {
+      return parseInt(this.playerX['home_run']) <= parseInt(this.playerY['home_run'])
+    },
+    runsBattedInX() {
+      return parseInt(this.playerX['runs_batted_in']) >= parseInt(this.playerY['runs_batted_in'])
+    },
+    runsBattedInY() {
+      return parseInt(this.playerX['runs_batted_in']) <= parseInt(this.playerY['runs_batted_in'])
+    },
+    stolenBaseX() {
+      return parseInt(this.playerX['stolen_base']) >= parseInt(this.playerY['stolen_base'])
+    },
+    stolenBaseY() {
+      return parseInt(this.playerX['stolen_base']) <= parseInt(this.playerY['stolen_base'])
+    },
+    onBasePercentageX() {
+      return parseFloat(this.playerX['on_base_percentage']) >= parseFloat(this.playerY['on_base_percentage'])
+    },
+    onBasePercentageY() {
+      return parseFloat(this.playerX['on_base_percentage']) <= parseFloat(this.playerY['on_base_percentage'])
+    },
+    onBasePlusSluggingX() {
+      return parseFloat(this.playerX['on_base_plus_slugging']) >= parseFloat(this.playerY['on_base_plus_slugging'])
+    },
+    onBasePlusSluggingY() {
+      return parseFloat(this.playerX['on_base_plus_slugging']) <= parseFloat(this.playerY['on_base_plus_slugging'])
+    },
+    walksX() {
+      return parseInt(this.playerX['walks']) >= parseInt(this.playerY['walks'])
+    },
+    walksY() {
+      return parseInt(this.playerX['walks']) <= parseInt(this.playerY['walks'])
+    },
+    hitByPitchX() {
+      return parseInt(this.playerX['hit_by_pitch']) >= parseInt(this.playerY['hit_by_pitch'])
+    },
+    hitByPitchY() {
+      return parseInt(this.playerX['hit_by_pitch']) <= parseInt(this.playerY['hit_by_pitch'])
+    },
+    scoringPositionBattingAverageX() {
+      return parseFloat(this.playerX['scoring_position_batting_average']) >= parseFloat(this.playerY['scoring_position_batting_average'])
+    },
+    scoringPositionBattingAverageY() {
+      return parseFloat(this.playerX['scoring_position_batting_average']) <= parseFloat(this.playerY['scoring_position_batting_average'])
+    },
+    strikeoutX() {
+      return parseInt(this.playerX['strikeout']) <= parseInt(this.playerY['strikeout'])
+    },
+    strikeoutY() {
+      return parseInt(this.playerX['strikeout']) >= parseInt(this.playerY['strikeout'])
+    },
+    errorX() {
+      return parseInt(this.playerX['error']) <= parseInt(this.playerY['error'])
+    },
+    errorY() {
+      return parseInt(this.playerX['error']) >= parseInt(this.playerY['error'])
+    }
+  }
+}
+</script>
+
+<style scoped>
+table > tr > td,th {
+  text-align: center;
+}
+
+.emphasis {
+  font-weight: bold;
+  color: red;
+}
+
+</style>

--- a/app/javascript/ComparePitcherScoreTable.vue
+++ b/app/javascript/ComparePitcherScoreTable.vue
@@ -3,40 +3,88 @@
     <v-btn icon fab small @click="closeModal()"><v-icon>mdi-close-circle</v-icon></v-btn>
     <table>
       <tr>
-        <td :class="['player-name', playerX['english_team_name']]">{{playerX.name}}</td><th>選手名</th><td :class="['player-name', playerY['english_team_name']]">{{playerY.name}}</td>
+        <td :class="['player-name', playerX['english_team_name']]">{{playerX.name}}</td>
+        <th>選手名</th>
+        <td :class="['player-name', playerY['english_team_name']]">{{playerY.name}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: earnedRunAverageX() }">{{playerX['earned_run_average']}}</td><th>防御率</th><td :class="{ emphasis: earnedRunAverageY() }">{{playerY['earned_run_average']}}</td>
+        <td :class="{ emphasis: isEmphasisFloat(playerY['earned_run_average'], playerX['earned_run_average']) }">
+          {{playerX['earned_run_average']}}
+        </td>
+        <th>防御率</th>
+        <td :class="{ emphasis: isEmphasisFloat(playerX['earned_run_average'], playerY['earned_run_average']) }">
+          {{playerY['earned_run_average']}}
+        </td>
       </tr>
       <tr>
-        <td :class="{ emphasis: winX() }">{{playerX['win']}}</td><th>勝</th><td :class="{ emphasis: winY() }">{{playerY['win']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['win'], playerY['win']) }">{{playerX['win']}}</td>
+        <th>勝</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['win'], playerX['win']) }">{{playerY['win']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: loseX() }">{{playerX['lose']}}</td><th>負</th><td :class="{ emphasis: loseY() }">{{playerY['lose']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerY['lose'], playerX['lose']) }">{{playerX['lose']}}</td>
+        <th>負</th>
+        <td :class="{ emphasis: isEmphasisInt(playerX['lose'], playerY['lose']) }">{{playerY['lose']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: inningsPitchedX() }">{{playerX['innings_pitched']}}</td><th>投球回</th><td :class="{ emphasis: inningsPitchedY() }">{{playerY['innings_pitched']}}</td>
+        <td :class="{ emphasis: isEmphasisFloat(playerX['innings_pitched'], playerY['innings_pitched']) }">
+          {{playerX['innings_pitched']}}
+        </td>
+        <th>投球回</th>
+        <td :class="{ emphasis: isEmphasisFloat(playerY['innings_pitched'], playerX['innings_pitched']) }">
+          {{playerY['innings_pitched']}}
+        </td>
       </tr>
       <tr>
-        <td :class="{ emphasis: pitchedX() }">{{playerX['pitched']}}</td><th>登板</th><td :class="{ emphasis: pitchedY() }">{{playerY['pitched']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['pitched'], playerY['pitched']) }">{{playerX['pitched']}}</td>
+        <th>登板</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['pitched'], playerX['pitched']) }">{{playerY['pitched']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: numberOfSaveX() }">{{playerX['number_of_save']}}</td><th>セーブ</th><td :class="{ emphasis: numberOfSaveY() }">{{playerY['number_of_save']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['number_of_save'], playerY['number_of_save']) }">
+          {{playerX['number_of_save']}}
+        </td>
+        <th>セーブ</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['number_of_save'], playerX['number_of_save']) }">
+          {{playerY['number_of_save']}}
+        </td>
       </tr>
       <tr>
-        <td :class="{ emphasis: holdPointX() }">{{playerX['hold_point']}}</td><th>HP</th><td :class="{ emphasis: holdPointY() }">{{playerY['hold_point']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['hold_point'], playerY['hold_point']) }">{{playerX['hold_point']}}</td>
+        <th>HP</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['hold_point'], playerX['hold_point']) }">{{playerY['hold_point']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: strikeoutX() }">{{playerX['strikeout']}}</td><th>三振</th><td :class="{ emphasis: strikeoutY() }">{{playerY['strikeout']}}</td>
+        <td :class="{ emphasis: isEmphasisInt(playerX['strikeout'], playerY['strikeout']) }">{{playerX['strikeout']}}</td>
+        <th>三振</th>
+        <td :class="{ emphasis: isEmphasisInt(playerY['strikeout'], playerX['strikeout']) }">{{playerY['strikeout']}}</td>
       </tr>
       <tr>
-        <td :class="{ emphasis: strikeoutsPerNineInningsX() }">{{playerX['strikeouts_per_nine_innings']}}</td><th>奪三振率</th><td :class="{ emphasis: strikeoutsPerNineInningsY() }">{{playerY['strikeouts_per_nine_innings']}}</td>
+        <td :class="{ emphasis: isEmphasisFloat(playerX['strikeouts_per_nine_innings'], playerY['strikeouts_per_nine_innings']) }">
+          {{playerX['strikeouts_per_nine_innings']}}
+        </td>
+        <th>奪三振率</th>
+        <td :class="{ emphasis: isEmphasisFloat(playerY['strikeouts_per_nine_innings'], playerX['strikeouts_per_nine_innings']) }">
+          {{playerY['strikeouts_per_nine_innings']}}
+        </td>
       </tr>
       <tr>
-        <td :class="{ emphasis: strikeoutToWalkRatioX() }">{{playerX['strikeout_to_walk_ratio']}}</td><th>K/BB</th><td :class="{ emphasis: strikeoutToWalkRatioY() }">{{playerY['strikeout_to_walk_ratio']}}</td>
+        <td :class="{ emphasis: isEmphasisFloat(playerX['strikeout_to_walk_ratio'], playerY['strikeout_to_walk_ratio']) }">
+          {{playerX['strikeout_to_walk_ratio']}}
+        </td>
+        <th>K/BB</th>
+        <td :class="{ emphasis: isEmphasisFloat(playerY['strikeout_to_walk_ratio'], playerX['strikeout_to_walk_ratio']) }">
+          {{playerY['strikeout_to_walk_ratio']}}
+        </td>
       </tr>
       <tr>
-        <td :class="{ emphasis: walksAndHitsPerInningsPitchedX() }">{{playerX['walks_and_hits_per_innings_pitched']}}</td><th>WHIP</th><td :class="{ emphasis: walksAndHitsPerInningsPitchedY() }">{{playerY['walks_and_hits_per_innings_pitched']}}</td>
+        <td :class="{ emphasis: isEmphasisFloat(playerY['walks_and_hits_per_innings_pitched'], playerX['walks_and_hits_per_innings_pitched']) }">
+          {{playerX['walks_and_hits_per_innings_pitched']}}
+        </td>
+        <th>WHIP</th>
+        <td :class="{ emphasis: isEmphasisFloat(playerX['walks_and_hits_per_innings_pitched'], playerY['walks_and_hits_per_innings_pitched']) }">
+          {{playerY['walks_and_hits_per_innings_pitched']}}
+        </td>
       </tr>
     </table>
   </v-container>
@@ -63,71 +111,11 @@ export default {
     closeModal() {
       this.$emit('close-modal')
     },
-    earnedRunAverageX() {
-      return parseFloat(this.playerX['earned_run_average']) <= parseFloat(this.playerY['earned_run_average'])
+    isEmphasisInt(playerScoreBefore, playerScoreAfter) {
+      return parseInt(playerScoreBefore) >= parseInt(playerScoreAfter)
     },
-    earnedRunAverageY() {
-      return parseFloat(this.playerX['earned_run_average']) >= parseFloat(this.playerY['earned_run_average'])
-    },
-    winX() {
-      return parseInt(this.playerX['win']) >= parseInt(this.playerY['win'])
-    },
-    winY() {
-      return parseInt(this.playerX['win']) <= parseInt(this.playerY['win'])
-    },
-    loseX() {
-      return parseFloat(this.playerX['lose']) <= parseFloat(this.playerY['lose'])
-    },
-    loseY() {
-      return parseFloat(this.playerX['lose']) >= parseFloat(this.playerY['lose'])
-    },
-    inningsPitchedX() {
-      return parseFloat(this.playerX['innings_pitched']) >= parseFloat(this.playerY['innings_pitched'])
-    },
-    inningsPitchedY() {
-      return parseFloat(this.playerX['innings_pitched']) <= parseFloat(this.playerY['innings_pitched'])
-    },
-    pitchedX() {
-      return parseInt(this.playerX['pitched']) >= parseInt(this.playerY['pitched'])
-    },
-    pitchedY() {
-      return parseInt(this.playerX['pitched']) <= parseInt(this.playerY['pitched'])
-    },
-    numberOfSaveX() {
-      return parseInt(this.playerX['number_of_save']) >= parseInt(this.playerY['number_of_save'])
-    },
-    numberOfSaveY() {
-      return parseInt(this.playerX['number_of_save']) <= parseInt(this.playerY['number_of_save'])
-    },
-    holdPointX() {
-      return parseInt(this.playerX['hold_point']) >= parseInt(this.playerY['hold_point'])
-    },
-    holdPointY() {
-      return parseInt(this.playerX['hold_point']) <= parseInt(this.playerY['hold_point'])
-    },
-    strikeoutX() {
-      return parseInt(this.playerX['strikeout']) >= parseInt(this.playerY['strikeout'])
-    },
-    strikeoutY() {
-      return parseInt(this.playerX['strikeout']) <= parseInt(this.playerY['strikeout'])
-    },
-    strikeoutsPerNineInningsX() {
-      return parseFloat(this.playerX['strikeouts_per_nine_innings']) >= parseFloat(this.playerY['strikeouts_per_nine_innings'])
-    },
-    strikeoutsPerNineInningsY() {
-      return parseFloat(this.playerX['strikeouts_per_nine_innings']) <= parseFloat(this.playerY['strikeouts_per_nine_innings'])
-    },
-    strikeoutToWalkRatioX() {
-      return parseFloat(this.playerX['strikeout_to_walk_ratio']) >= parseFloat(this.playerY['strikeout_to_walk_ratio'])
-    },
-    strikeoutToWalkRatioY() {
-      return parseFloat(this.playerX['strikeout_to_walk_ratio']) <= parseFloat(this.playerY['strikeout_to_walk_ratio'])
-    },
-    walksAndHitsPerInningsPitchedX() {
-      return parseFloat(this.playerX['walks_and_hits_per_innings_pitched']) <= parseFloat(this.playerY['walks_and_hits_per_innings_pitched'])
-    },
-    walksAndHitsPerInningsPitchedY() {
-      return parseFloat(this.playerX['walks_and_hits_per_innings_pitched']) >= parseFloat(this.playerY['walks_and_hits_per_innings_pitched'])
+    isEmphasisFloat(playerScoreBefore, playerScoreAfter) {
+      return parseFloat(playerScoreBefore) >= parseFloat(playerScoreAfter)
     }
   }
 }

--- a/app/javascript/ComparePitcherScoreTable.vue
+++ b/app/javascript/ComparePitcherScoreTable.vue
@@ -57,7 +57,7 @@ export default {
     }
   },
   mounted() {
-    [this.playerX, this.playerY] = this.checkedPlayers
+    [this.playerY, this.playerX] = this.checkedPlayers
   },
   methods: {
     closeModal() {

--- a/app/javascript/ComparePitcherScoreTable.vue
+++ b/app/javascript/ComparePitcherScoreTable.vue
@@ -1,9 +1,9 @@
 <template>
   <v-container id="app">
-    <h4>選手比較</h4>
+    <v-btn icon fab small @click="closeModal()"><v-icon>mdi-close-circle</v-icon></v-btn>
     <table>
       <tr>
-        <td>{{playerX.name}}</td><th>選手名</th><td>{{playerY.name}}</td>
+        <td :class="['player-name', playerX['english_team_name']]">{{playerX.name}}</td><th>選手名</th><td :class="['player-name', playerY['english_team_name']]">{{playerY.name}}</td>
       </tr>
       <tr>
         <td :class="{ emphasis: earnedRunAverageX() }">{{playerX['earned_run_average']}}</td><th>防御率</th><td :class="{ emphasis: earnedRunAverageY() }">{{playerY['earned_run_average']}}</td>
@@ -60,6 +60,9 @@ export default {
     [this.playerX, this.playerY] = this.checkedPlayers
   },
   methods: {
+    closeModal() {
+      this.$emit('close-modal')
+    },
     earnedRunAverageX() {
       return parseFloat(this.playerX['earned_run_average']) <= parseFloat(this.playerY['earned_run_average'])
     },
@@ -131,12 +134,118 @@ export default {
 </script>
 
 <style scoped>
-table > tr > td,th {
+.v-container {
+  position: relative;
+}
+
+table {
+  width: 80%;
+  margin: auto;
+  border: 1px solid #dcdfe6;
+  border-collapse: collapse
+}
+
+table th {
+  color: #606266;
+  vertical-align: bottom;
+  border-bottom: 1px solid #dcdfe6;
+  background: linear-gradient(#f4f5f8,#f1f3f6);
+  padding: 10px 0;
   text-align: center;
+}
+
+table td {
+  padding: 10px 0;
+  text-align: center;
+  width: 35%;
+}
+
+.player-name {
+  font-weight: bold;
+  font-size: 1.2rem;
+  background: linear-gradient(#f4f5f8,#f1f3f6);
+}
+
+.v-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 .emphasis {
   font-weight: bold;
   color: red;
+}
+
+.hawks {
+  content: '';
+  border-bottom: thick solid #FEA409;
+  padding-bottom: 4px;
+}
+
+.marines {
+  content: '';
+  border-bottom: thick solid #6E6E6E;
+  padding-bottom: 4px;
+}
+
+.lions {
+  content: '';
+  border-bottom: thick solid #192546;
+  padding-bottom: 4px;
+}
+
+.eagles {
+  content: '';
+  border-bottom: thick solid #7F001E;
+  padding-bottom: 4px;
+}
+
+.fighters {
+  content: '';
+  border-bottom: thick solid #285A8A;
+  padding-bottom: 4px;
+}
+
+.buffaloes {
+  content: '';
+  border-bottom: thick solid #34328A;
+  padding-bottom: 4px;
+}
+
+.giants {
+  content: '';
+  border-bottom: thick solid #E96D06;
+  padding-bottom: 4px;
+}
+
+.tigers {
+  content: '';
+  border-bottom: thick solid #FED80C;
+  padding-bottom: 4px;
+}
+
+.dragons {
+  content: '';
+  border-bottom: thick solid #113C7C;
+  padding-bottom: 4px;
+}
+
+.baystars {
+  content: '';
+  border-bottom: thick solid #1182D8;
+  padding-bottom: 4px;
+}
+
+.carp {
+  content: '';
+  border-bottom: thick solid #C70019;
+  padding-bottom: 4px;
+}
+
+.swallows {
+  content: '';
+  border-bottom: thick solid #1A753E;
+  padding-bottom: 4px;
 }
 </style>

--- a/app/javascript/ComparePitcherScoreTable.vue
+++ b/app/javascript/ComparePitcherScoreTable.vue
@@ -1,0 +1,142 @@
+<template>
+  <v-container id="app">
+    <h4>選手比較</h4>
+    <table>
+      <tr>
+        <td>{{playerX.name}}</td><th>選手名</th><td>{{playerY.name}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: earnedRunAverageX() }">{{playerX['earned_run_average']}}</td><th>防御率</th><td :class="{ emphasis: earnedRunAverageY() }">{{playerY['earned_run_average']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: winX() }">{{playerX['win']}}</td><th>勝</th><td :class="{ emphasis: winY() }">{{playerY['win']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: loseX() }">{{playerX['lose']}}</td><th>負</th><td :class="{ emphasis: loseY() }">{{playerY['lose']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: inningsPitchedX() }">{{playerX['innings_pitched']}}</td><th>投球回</th><td :class="{ emphasis: inningsPitchedY() }">{{playerY['innings_pitched']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: pitchedX() }">{{playerX['pitched']}}</td><th>登板</th><td :class="{ emphasis: pitchedY() }">{{playerY['pitched']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: numberOfSaveX() }">{{playerX['number_of_save']}}</td><th>セーブ</th><td :class="{ emphasis: numberOfSaveY() }">{{playerY['number_of_save']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: holdPointX() }">{{playerX['hold_point']}}</td><th>HP</th><td :class="{ emphasis: holdPointY() }">{{playerY['hold_point']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: strikeoutX() }">{{playerX['strikeout']}}</td><th>三振</th><td :class="{ emphasis: strikeoutY() }">{{playerY['strikeout']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: strikeoutsPerNineInningsX() }">{{playerX['strikeouts_per_nine_innings']}}</td><th>奪三振率</th><td :class="{ emphasis: strikeoutsPerNineInningsY() }">{{playerY['strikeouts_per_nine_innings']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: strikeoutToWalkRatioX() }">{{playerX['strikeout_to_walk_ratio']}}</td><th>K/BB</th><td :class="{ emphasis: strikeoutToWalkRatioY() }">{{playerY['strikeout_to_walk_ratio']}}</td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: walksAndHitsPerInningsPitchedX() }">{{playerX['walks_and_hits_per_innings_pitched']}}</td><th>WHIP</th><td :class="{ emphasis: walksAndHitsPerInningsPitchedY() }">{{playerY['walks_and_hits_per_innings_pitched']}}</td>
+      </tr>
+    </table>
+  </v-container>
+</template>
+
+<script>
+export default {
+  props: {
+    checkedPlayers: {
+      type: Array,
+      require: true
+    }
+  },
+  data: function () {
+    return {
+      playerX: null,
+      playerY: null
+    }
+  },
+  mounted() {
+    [this.playerX, this.playerY] = this.checkedPlayers
+  },
+  methods: {
+    earnedRunAverageX() {
+      return parseFloat(this.playerX['earned_run_average']) <= parseFloat(this.playerY['earned_run_average'])
+    },
+    earnedRunAverageY() {
+      return parseFloat(this.playerX['earned_run_average']) >= parseFloat(this.playerY['earned_run_average'])
+    },
+    winX() {
+      return parseInt(this.playerX['win']) >= parseInt(this.playerY['win'])
+    },
+    winY() {
+      return parseInt(this.playerX['win']) <= parseInt(this.playerY['win'])
+    },
+    loseX() {
+      return parseFloat(this.playerX['lose']) <= parseFloat(this.playerY['lose'])
+    },
+    loseY() {
+      return parseFloat(this.playerX['lose']) >= parseFloat(this.playerY['lose'])
+    },
+    inningsPitchedX() {
+      return parseFloat(this.playerX['innings_pitched']) >= parseFloat(this.playerY['innings_pitched'])
+    },
+    inningsPitchedY() {
+      return parseFloat(this.playerX['innings_pitched']) <= parseFloat(this.playerY['innings_pitched'])
+    },
+    pitchedX() {
+      return parseInt(this.playerX['pitched']) >= parseInt(this.playerY['pitched'])
+    },
+    pitchedY() {
+      return parseInt(this.playerX['pitched']) <= parseInt(this.playerY['pitched'])
+    },
+    numberOfSaveX() {
+      return parseInt(this.playerX['number_of_save']) >= parseInt(this.playerY['number_of_save'])
+    },
+    numberOfSaveY() {
+      return parseInt(this.playerX['number_of_save']) <= parseInt(this.playerY['number_of_save'])
+    },
+    holdPointX() {
+      return parseInt(this.playerX['hold_point']) >= parseInt(this.playerY['hold_point'])
+    },
+    holdPointY() {
+      return parseInt(this.playerX['hold_point']) <= parseInt(this.playerY['hold_point'])
+    },
+    strikeoutX() {
+      return parseInt(this.playerX['strikeout']) >= parseInt(this.playerY['strikeout'])
+    },
+    strikeoutY() {
+      return parseInt(this.playerX['strikeout']) <= parseInt(this.playerY['strikeout'])
+    },
+    strikeoutsPerNineInningsX() {
+      return parseFloat(this.playerX['strikeouts_per_nine_innings']) >= parseFloat(this.playerY['strikeouts_per_nine_innings'])
+    },
+    strikeoutsPerNineInningsY() {
+      return parseFloat(this.playerX['strikeouts_per_nine_innings']) <= parseFloat(this.playerY['strikeouts_per_nine_innings'])
+    },
+    strikeoutToWalkRatioX() {
+      return parseFloat(this.playerX['strikeout_to_walk_ratio']) >= parseFloat(this.playerY['strikeout_to_walk_ratio'])
+    },
+    strikeoutToWalkRatioY() {
+      return parseFloat(this.playerX['strikeout_to_walk_ratio']) <= parseFloat(this.playerY['strikeout_to_walk_ratio'])
+    },
+    walksAndHitsPerInningsPitchedX() {
+      return parseFloat(this.playerX['walks_and_hits_per_innings_pitched']) <= parseFloat(this.playerY['walks_and_hits_per_innings_pitched'])
+    },
+    walksAndHitsPerInningsPitchedY() {
+      return parseFloat(this.playerX['walks_and_hits_per_innings_pitched']) >= parseFloat(this.playerY['walks_and_hits_per_innings_pitched'])
+    }
+  }
+}
+</script>
+
+<style scoped>
+table > tr > td,th {
+  text-align: center;
+}
+
+.emphasis {
+  font-weight: bold;
+  color: red;
+}
+</style>

--- a/app/javascript/RegisteredBatters.vue
+++ b/app/javascript/RegisteredBatters.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app">
+  <v-app id="app">
     <vue-good-table
       v-if="batters && batters.length"
       @on-selected-rows-change="selectionChanged"
@@ -32,16 +32,31 @@
         </span>
       </template>
       <div slot="selected-row-actions">
-        <el-button type="danger" size="small" round @click="releaseProcessing">解除する</el-button>
+        <v-dialog
+            v-model="dialog"
+            width="600px"
+        >
+          <template v-slot:activator="{ on, attrs }">
+            <el-button v-bind="attrs" v-on="on" type="primary" size="small" round>比較する</el-button>
+          </template>
+          <v-card>
+            <compare-batter-score-table :checked-players="checkedPlayers"></compare-batter-score-table>
+          </v-card>
+        </v-dialog>
+        <el-button type="danger" round size="small" @click="releaseProcessing">解除する</el-button>
       </div>
     </vue-good-table>
-  </div>
+  </v-app>
 </template>
 
 <script>
 import {axiosClient} from './axios_client'
+import compareBatterScoreTable from './CompareBatterScoreTable'
 
 export default {
+  components: {
+    compareBatterScoreTable
+  },
   props: {
     batters: {
       type: Array,
@@ -51,6 +66,7 @@ export default {
   data: function () {
     return {
       checkedPlayers: [],
+      dialog: false,
       columns: [
         {
           label: '背番号',
@@ -196,6 +212,11 @@ export default {
   position: initial;
   opacity: 1.0;
   pointer-events: auto;
+}
+
+.el-button {
+  color: white;
+  font-weight: bold;
 }
 
 .player-name {

--- a/app/javascript/RegisteredBatters.vue
+++ b/app/javascript/RegisteredBatters.vue
@@ -37,7 +37,7 @@
             width="600px"
         >
           <template v-slot:activator="{ on, attrs }">
-            <el-button v-bind="attrs" v-on="on" type="primary" size="small" round>比較する</el-button>
+            <el-button v-bind="attrs" v-on="on" type="primary" size="small" round :disabled="checkedPlayers.length !== 2">比較する</el-button>
           </template>
           <v-card>
             <compare-batter-score-table :checked-players="checkedPlayers"></compare-batter-score-table>

--- a/app/javascript/RegisteredBatters.vue
+++ b/app/javascript/RegisteredBatters.vue
@@ -40,7 +40,7 @@
             <el-button v-bind="attrs" v-on="on" type="primary" size="small" round :disabled="checkedPlayers.length !== 2">比較する</el-button>
           </template>
           <v-card>
-            <compare-batter-score-table :checked-players="checkedPlayers" @close-modal="dialog = false"></compare-batter-score-table>
+            <compare-batter-score-table v-if="checkedPlayers.length === 2" :checked-players="checkedPlayers" @close-modal="dialog = false"></compare-batter-score-table>
           </v-card>
         </v-dialog>
         <el-button type="danger" round size="small" @click="releaseProcessing">解除する</el-button>

--- a/app/javascript/RegisteredBatters.vue
+++ b/app/javascript/RegisteredBatters.vue
@@ -40,7 +40,7 @@
             <el-button v-bind="attrs" v-on="on" type="primary" size="small" round :disabled="checkedPlayers.length !== 2">比較する</el-button>
           </template>
           <v-card>
-            <compare-batter-score-table :checked-players="checkedPlayers"></compare-batter-score-table>
+            <compare-batter-score-table :checked-players="checkedPlayers" @close-modal="dialog = false"></compare-batter-score-table>
           </v-card>
         </v-dialog>
         <el-button type="danger" round size="small" @click="releaseProcessing">解除する</el-button>

--- a/app/javascript/RegisteredPitchers.vue
+++ b/app/javascript/RegisteredPitchers.vue
@@ -40,7 +40,7 @@
             <el-button v-bind="attrs" v-on="on" type="primary" size="small" round :disabled="checkedPlayers.length !== 2">比較する</el-button>
           </template>
           <v-card>
-            <compare-pitcher-score-table :checked-players="checkedPlayers" @close-modal="dialog = false"></compare-pitcher-score-table>
+            <compare-pitcher-score-table v-if="checkedPlayers.length === 2" :checked-players="checkedPlayers" @close-modal="dialog = false"></compare-pitcher-score-table>
           </v-card>
         </v-dialog>
         <el-button type="danger" size="small" round @click="releaseProcessing">解除する</el-button>

--- a/app/javascript/RegisteredPitchers.vue
+++ b/app/javascript/RegisteredPitchers.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app">
+  <v-app id="app">
     <vue-good-table
       v-if="pitchers && pitchers.length"
       @on-selected-rows-change="selectionChanged"
@@ -32,16 +32,31 @@
         </span>
       </template>
       <div slot="selected-row-actions">
+        <v-dialog
+            v-model="dialog"
+            width="600px"
+        >
+          <template v-slot:activator="{ on, attrs }">
+            <el-button v-bind="attrs" v-on="on" type="primary" size="small" round>比較する</el-button>
+          </template>
+          <v-card>
+            <compare-pitcher-score-table :checked-players="checkedPlayers"></compare-pitcher-score-table>
+          </v-card>
+        </v-dialog>
         <el-button type="danger" size="small" round @click="releaseProcessing">解除する</el-button>
       </div>
     </vue-good-table>
-  </div>
+  </v-app>
 </template>
 
 <script>
 import {axiosClient} from './axios_client'
+import comparePitcherScoreTable from './ComparePitcherScoreTable'
 
 export default {
+  components: {
+    comparePitcherScoreTable
+  },
   props: {
     pitchers: {
       type: Array,
@@ -51,6 +66,7 @@ export default {
   data: function () {
     return {
       checkedPlayers: [],
+      dialog: false,
       columns: [
         {
           label: '背番号',
@@ -183,6 +199,11 @@ export default {
   position: initial;
   opacity: 1.0;
   pointer-events: auto;
+}
+
+.el-button {
+  color: white;
+  font-weight: bold;
 }
 
 .player-name {

--- a/app/javascript/RegisteredPitchers.vue
+++ b/app/javascript/RegisteredPitchers.vue
@@ -37,7 +37,7 @@
             width="600px"
         >
           <template v-slot:activator="{ on, attrs }">
-            <el-button v-bind="attrs" v-on="on" type="primary" size="small" round>比較する</el-button>
+            <el-button v-bind="attrs" v-on="on" type="primary" size="small" round :disabled="checkedPlayers.length !== 2">比較する</el-button>
           </template>
           <v-card>
             <compare-pitcher-score-table :checked-players="checkedPlayers"></compare-pitcher-score-table>

--- a/app/javascript/RegisteredPitchers.vue
+++ b/app/javascript/RegisteredPitchers.vue
@@ -40,7 +40,7 @@
             <el-button v-bind="attrs" v-on="on" type="primary" size="small" round :disabled="checkedPlayers.length !== 2">比較する</el-button>
           </template>
           <v-card>
-            <compare-pitcher-score-table :checked-players="checkedPlayers"></compare-pitcher-score-table>
+            <compare-pitcher-score-table :checked-players="checkedPlayers" @close-modal="dialog = false"></compare-pitcher-score-table>
           </v-card>
         </v-dialog>
         <el-button type="danger" size="small" round @click="releaseProcessing">解除する</el-button>

--- a/app/javascript/registered_players.js
+++ b/app/javascript/registered_players.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import RegisteredPlayers from './RegisteredPlayers.vue'
 import VueGoodTablePlugin from 'vue-good-table'
 import 'vue-good-table/dist/vue-good-table.css'
+import Vuetify from 'vuetify'
 
 Vue.use(VueGoodTablePlugin)
 
@@ -9,7 +10,8 @@ document.addEventListener('turbolinks:load', () => {
   const registeredPlayers = document.getElementById('js-registered-players')
   if (registeredPlayers) {
     new Vue({
-      render: h => h(RegisteredPlayers)
+      render: h => h(RegisteredPlayers),
+      vuetify: new Vuetify()
     }).$mount('#js-registered-players')
   }
 })


### PR DESCRIPTION
## 目的
チェックボックスで選択した選手を1対1で比較し、優れている成績を強調表示するテーブルをモーダル表示できるようにする。

## 変更点
- 選手比較テーブルを表示するためのボタンを追加
  - 選択している選手が二人のときのみ押せるように実装
- 選手比較テーブルを実装

[![Image from Gyazo](https://i.gyazo.com/0dc3bbe04870799b55941bc431c44c92.gif)](https://gyazo.com/0dc3bbe04870799b55941bc431c44c92)