### PR TITLE
タブでの切り替え機能を追加

### DIFF
--- a/app/javascript/AllTeams.vue
+++ b/app/javascript/AllTeams.vue
@@ -1,37 +1,46 @@
 <template>
-  <div id="app">
+  <v-app id="app">
     <v-container>
-      <h4>チーム別選手一覧</h4>
-      <h5 style="font-weight: bold;">セ・リーグ</h5>
-      <v-row>
-        <v-expansion-panels popout>
-          <v-expansion-panel v-for="team in teams['central']" :key="team['name']">
-            <v-expansion-panel-header>
-              <v-img :src="displayTeamLogo(team['english_team_name'])" max-width="64px"></v-img>
-              <span>{{team['formal_name']}}</span>
-            </v-expansion-panel-header>
-            <v-expansion-panel-content>
-              <team-players v-if="showTeamPlayersComponent" :selected-team="team['name']" :same-league-teams="teams['central']" :registered-players="registeredPlayers"></team-players>
-            </v-expansion-panel-content>
-          </v-expansion-panel>
-        </v-expansion-panels>
-      </v-row>
-      <h5 style="font-weight: bold">パ・リーグ</h5>
-      <v-row>
-        <v-expansion-panels popout>
-          <v-expansion-panel v-for="team in teams['pacific']" :key="team['name']">
-            <v-expansion-panel-header>
-              <v-img :src="displayTeamLogo(team['english_team_name'])" max-width="64px"></v-img>
-              <span>{{team['formal_name']}}</span>
-            </v-expansion-panel-header>
-            <v-expansion-panel-content>
-              <team-players v-if="showTeamPlayersComponent" :selected-team="team['name']" :same-league-teams="teams['pacific']" :registered-players="registeredPlayers"></team-players>
-            </v-expansion-panel-content>
-          </v-expansion-panel>
-        </v-expansion-panels>
-      </v-row>
+      <h5 class="center">チームから探す</h5>
+      <v-tabs v-model="tab" :grow="true" :slider-size="5" height="60px">
+        <v-tab class="central-tab" @click="tabsSliderColor = '#14A26F'">セ・リーグ</v-tab>
+        <v-tab class="pacific-tab" @click="tabsSliderColor = '#30A6CC'">パ・リーグ</v-tab>
+        <v-tabs-slider :color="changeColor" />
+      </v-tabs>
+      <v-tabs-items v-model="tab">
+        <v-tab-item>
+          <v-row>
+            <v-expansion-panels popout focusable>
+              <v-expansion-panel v-for="team in teams['central']" :key="team['name']">
+                <v-expansion-panel-header>
+                  <v-img :src="displayTeamLogo(team['english_team_name'])" max-width="64px"></v-img>
+                  <span>{{team['formal_name']}}</span>
+                </v-expansion-panel-header>
+                <v-expansion-panel-content>
+                  <team-players v-if="showTeamPlayersComponent" :selected-team="team['name']" :same-league-teams="teams['central']" :registered-players="registeredPlayers"></team-players>
+                </v-expansion-panel-content>
+              </v-expansion-panel>
+            </v-expansion-panels>
+          </v-row>
+        </v-tab-item>
+        <v-tab-item>
+          <v-row>
+            <v-expansion-panels focusable>
+              <v-expansion-panel v-for="team in teams['pacific']" :key="team['name']">
+                <v-expansion-panel-header>
+                  <v-img :src="displayTeamLogo(team['english_team_name'])" max-width="64px"></v-img>
+                  <span>{{team['formal_name']}}</span>
+                </v-expansion-panel-header>
+                <v-expansion-panel-content>
+                  <team-players v-if="showTeamPlayersComponent" :selected-team="team['name']" :same-league-teams="teams['pacific']" :registered-players="registeredPlayers"></team-players>
+                </v-expansion-panel-content>
+              </v-expansion-panel>
+            </v-expansion-panels>
+          </v-row>
+        </v-tab-item>
+      </v-tabs-items>
     </v-container>
-  </div>
+  </v-app>
 </template>
 
 <script>
@@ -43,7 +52,9 @@ export default {
     return {
       teams: {},
       registeredPlayers: [],
-      showTeamPlayersComponent: false
+      showTeamPlayersComponent: false,
+      tab: null,
+      tabsSliderColor: '#14A26F'
     }
   },
   created() {
@@ -57,6 +68,11 @@ export default {
   },
   components: {
     TeamPlayers
+  },
+  computed: {
+    changeColor() {
+      return this.tabsSliderColor
+    }
   },
   methods: {
     fetchRegisteredPlayers() {
@@ -79,5 +95,23 @@ span{
   font-family: Helvetica,Arial,"メイリオ","ヒラギノ W3","Hiragino Sans","ヒラギノ角ゴシック","ＭＳ Ｐゴシック",sans-serif;
   text-align: left;
   margin-left: 24px;
+}
+
+.v-tab {
+  font-size: 1.3rem;
+  font-weight: bold
+}
+
+.central-tab {
+  color: #14A26F
+}
+
+.pacific-tab {
+  color: #30A6CC
+}
+
+h5 {
+  font-weight: bold;
+  font-family: Helvetica,Arial,"メイリオ","ヒラギノ W3","Hiragino Sans","ヒラギノ角ゴシック","ＭＳ Ｐゴシック",sans-serif;
 }
 </style>

--- a/app/javascript/RegisteredBatters.vue
+++ b/app/javascript/RegisteredBatters.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app id="app">
+  <div id="app">
     <vue-good-table
       v-if="batters && batters.length"
       @on-selected-rows-change="selectionChanged"
@@ -46,7 +46,7 @@
         <el-button type="danger" round size="small" @click="releaseProcessing">解除する</el-button>
       </div>
     </vue-good-table>
-  </v-app>
+  </div>
 </template>
 
 <script>

--- a/app/javascript/RegisteredPitchers.vue
+++ b/app/javascript/RegisteredPitchers.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app id="app">
+  <div id="app">
     <vue-good-table
       v-if="pitchers && pitchers.length"
       @on-selected-rows-change="selectionChanged"
@@ -46,7 +46,7 @@
         <el-button type="danger" size="small" round @click="releaseProcessing">解除する</el-button>
       </div>
     </vue-good-table>
-  </v-app>
+  </div>
 </template>
 
 <script>

--- a/app/javascript/RegisteredPlayers.vue
+++ b/app/javascript/RegisteredPlayers.vue
@@ -1,14 +1,21 @@
 <template>
-  <v-container :fluid="true" id="app">
-    <div>
-      <h5>野手</h5>
-      <registered-batters :batters="registeredPlayers['batters']"></registered-batters>
-    </div>
-    <div>
-      <h5>投手</h5>
-      <registered-pitchers :pitchers="registeredPlayers['pitchers']"></registered-pitchers>
-    </div>
-  </v-container>
+  <v-app>
+    <v-container :fluid="true" id="app">
+      <h5 class="center">登録済み選手一覧</h5>
+      <v-tabs v-model="tab" :grow="true">
+        <v-tab>野手</v-tab>
+        <v-tab>投手</v-tab>
+      </v-tabs>
+      <v-tabs-items v-model="tab">
+        <v-tab-item>
+          <registered-batters :batters="registeredPlayers['batters']"></registered-batters>
+        </v-tab-item>
+        <v-tab-item>
+          <registered-pitchers :pitchers="registeredPlayers['pitchers']"></registered-pitchers>
+        </v-tab-item>
+      </v-tabs-items>
+    </v-container>
+  </v-app>
 </template>
 
 <script>
@@ -19,7 +26,8 @@ import {axiosClient} from './axios_client'
 export default {
   data: function () {
     return {
-      registeredPlayers: {}
+      registeredPlayers: {},
+      tab: null
     }
   },
   components: {
@@ -36,3 +44,15 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.v-tab {
+  font-size: 1.4rem;
+  font-weight: bold;
+}
+
+h5 {
+  font-weight: bold;
+  font-family: Helvetica,Arial,"メイリオ","ヒラギノ W3","Hiragino Sans","ヒラギノ角ゴシック","ＭＳ Ｐゴシック",sans-serif;
+}
+</style>

--- a/app/views/registered_players/index.html.slim
+++ b/app/views/registered_players/index.html.slim
@@ -1,3 +1,4 @@
-span.right
-  = "#{l @data_update_at}更新"
+.right-align
+  span
+    = "#{l @data_update_at}更新"
 #js-registered-players


### PR DESCRIPTION
## 目的
登録済み選手画面での野手と投手、チームから探す画面でのセ・リーグとパ・リーグが縦に並んでいる状態なので、タブでそれぞれ切り替えができるように変更する。

## 変更点
- 登録済み選手画面にタブでの切り替え機能を追加
- チームから探す画面にタブでの切り替え機能を追加
- 見出しを調整

[![Image from Gyazo](https://i.gyazo.com/c78946cef61931ccc6f893d7c3fb3249.gif)](https://gyazo.com/c78946cef61931ccc6f893d7c3fb3249)