### PR TITLE
登録済み選手画面にブランクページを用意する

### DIFF
--- a/app/javascript/AllTeams.vue
+++ b/app/javascript/AllTeams.vue
@@ -94,12 +94,13 @@ span{
   font-weight: bold;
   font-family: Helvetica,Arial,"メイリオ","ヒラギノ W3","Hiragino Sans","ヒラギノ角ゴシック","ＭＳ Ｐゴシック",sans-serif;
   text-align: left;
-  margin-left: 24px;
+  margin-left: 24px
 }
 
 .v-tab {
   font-size: 1.3rem;
-  font-weight: bold
+  font-weight: bold;
+  font-family: Helvetica,Arial,"メイリオ","ヒラギノ W3","Hiragino Sans","ヒラギノ角ゴシック","ＭＳ Ｐゴシック",sans-serif
 }
 
 .central-tab {

--- a/app/javascript/AllTeams.vue
+++ b/app/javascript/AllTeams.vue
@@ -94,21 +94,21 @@ span{
   font-weight: bold;
   font-family: Helvetica,Arial,"メイリオ","ヒラギノ W3","Hiragino Sans","ヒラギノ角ゴシック","ＭＳ Ｐゴシック",sans-serif;
   text-align: left;
-  margin-left: 24px
+  margin-left: 24px;
 }
 
 .v-tab {
   font-size: 1.3rem;
   font-weight: bold;
-  font-family: Helvetica,Arial,"メイリオ","ヒラギノ W3","Hiragino Sans","ヒラギノ角ゴシック","ＭＳ Ｐゴシック",sans-serif
+  font-family: Helvetica,Arial,"メイリオ","ヒラギノ W3","Hiragino Sans","ヒラギノ角ゴシック","ＭＳ Ｐゴシック",sans-serif;
 }
 
 .central-tab {
-  color: #14A26F
+  color: #14A26F;
 }
 
 .pacific-tab {
-  color: #30A6CC
+  color: #30A6CC;
 }
 
 h5 {

--- a/app/javascript/BlankPage.vue
+++ b/app/javascript/BlankPage.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-container class="center">
+    <v-btn
+        dark
+        large
+        color="light-green"
+        class="mb-6"
+        height="64px"
+        href="/players"
+    >
+      <v-icon dark size="40px">
+        mdi-plus
+      </v-icon>
+    </v-btn>
+    <div>
+      <p>まだ選手が登録されていません</p>
+      <p>気になる選手を登録して成績をチェックしましょう！</p>
+    </div>
+  </v-container>
+</template>
+
+<script>
+export default {
+}
+</script>
+
+<style scoped>
+.container {
+  margin-top: 160px;
+}
+
+p {
+  font-weight: bold;
+  color: #6E6E6E;
+}
+</style>

--- a/app/javascript/BlankPage.vue
+++ b/app/javascript/BlankPage.vue
@@ -32,5 +32,6 @@ export default {
 p {
   font-weight: bold;
   color: #6E6E6E;
+  font-family: Helvetica,Arial,"メイリオ","ヒラギノ W3","Hiragino Sans","ヒラギノ角ゴシック","ＭＳ Ｐゴシック",sans-serif;
 }
 </style>

--- a/app/javascript/CompareBatterScoreTable.vue
+++ b/app/javascript/CompareBatterScoreTable.vue
@@ -136,7 +136,7 @@ table {
   width: 80%;
   margin: auto;
   border: 1px solid #dcdfe6;
-  border-collapse: collapse
+  border-collapse: collapse;
 }
 
 table th {

--- a/app/javascript/ComparePitcherScoreTable.vue
+++ b/app/javascript/ComparePitcherScoreTable.vue
@@ -130,7 +130,7 @@ table {
   width: 80%;
   margin: auto;
   border: 1px solid #dcdfe6;
-  border-collapse: collapse
+  border-collapse: collapse;
 }
 
 table th {

--- a/app/javascript/RegisteredPlayers.vue
+++ b/app/javascript/RegisteredPlayers.vue
@@ -8,10 +8,12 @@
       </v-tabs>
       <v-tabs-items v-model="tab">
         <v-tab-item>
-          <registered-batters :batters="registeredPlayers['batters']"></registered-batters>
+          <blank-page v-if="registeredPlayers['batters'].length === 0"></blank-page>
+          <registered-batters v-else :batters="registeredPlayers['batters']"></registered-batters>
         </v-tab-item>
         <v-tab-item>
-          <registered-pitchers :pitchers="registeredPlayers['pitchers']"></registered-pitchers>
+          <blank-page v-if="registeredPlayers['pitchers'].length === 0"></blank-page>
+          <registered-pitchers v-else :pitchers="registeredPlayers['pitchers']"></registered-pitchers>
         </v-tab-item>
       </v-tabs-items>
     </v-container>
@@ -21,6 +23,7 @@
 <script>
 import RegisteredBatters from './RegisteredBatters'
 import RegisteredPitchers from './RegisteredPitchers'
+import BlankPage from './BlankPage'
 import {axiosClient} from './axios_client'
 
 export default {
@@ -32,7 +35,8 @@ export default {
   },
   components: {
     RegisteredBatters,
-    RegisteredPitchers
+    RegisteredPitchers,
+    BlankPage
   },
   created() {
     this.fetchRegisteredPlayers()

--- a/app/javascript/RegisteredPlayers.vue
+++ b/app/javascript/RegisteredPlayers.vue
@@ -53,6 +53,7 @@ export default {
 .v-tab {
   font-size: 1.4rem;
   font-weight: bold;
+  font-family: Helvetica,Arial,"メイリオ","ヒラギノ W3","Hiragino Sans","ヒラギノ角ゴシック","ＭＳ Ｐゴシック",sans-serif;
 }
 
 h5 {

--- a/app/javascript/TeamPlayers.vue
+++ b/app/javascript/TeamPlayers.vue
@@ -90,10 +90,6 @@ export default {
 </script>
 
 <style scoped>
-
-</style>
-
-<style lang="scss" scoped>
 /deep/ .el-table th>.cell {
   font-size: 1rem;
 }

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,7 +8,7 @@ html
     = csp_meta_tag
     = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
-  body(style="display: flex; flex-direction: column; min-height: 100vh;")
+  body(style="display: flex; flex-direction: column; min-height: 100vh; font-family: Helvetica,Arial,'メイリオ','ヒラギノ W','Hiragino Sans','ヒラギノ角ゴシック','ＭＳ Ｐゴシック',sans-serif;")
     header
       nav.grey.darken-3 style="height: 72px;"
         .nav-wrapper


### PR DESCRIPTION
## 目的
選手未登録の場合に表示するブランクページのコンポーネントを用意する。

## 変更点
- ブランクページのコンポーネントBlankPage.vueを実装
  - 表示されているプラスマークはチームから探す画面へのリンクボタンとなっている
- 各部にフォントを指定

![image](https://user-images.githubusercontent.com/59789739/104667962-8958da80-571a-11eb-9710-7183e024353d.png)

