### PR TITLE
検索候補の表示に背番号を追加

### DIFF
--- a/app/javascript/PlayerSearch.vue
+++ b/app/javascript/PlayerSearch.vue
@@ -12,7 +12,7 @@
               mode="select"
               :filter-by-query="true">
             <template slot="suggestion-item" slot-scope="{ suggestion }">
-              <span>{{ suggestion.name }}</span>
+              <span>{{ `${suggestion.number} ${suggestion.name}` }}</span>
             </template>
           </vue-simple-suggest>
         </v-col>


### PR DESCRIPTION
## 目的
同姓同名の選手の見分けをつけやすくするため、登録名で検索の機能のサジェストに背番号の表示を追加。

## 変更点
- サジェストに背番号の表示を追加

## 課題
- 別チームに同姓同名の選手がいて背番号も同じ場合見分けがつかないため、チームカラーの表示も必要

[![Image from Gyazo](https://i.gyazo.com/6fb0331d8cba93a892b2946b051a3197.gif)](https://gyazo.com/6fb0331d8cba93a892b2946b051a3197)