### PR TITLE
登録済み選手一覧のレイアウトを調整

### DIFF
--- a/app/javascript/BlankPage.vue
+++ b/app/javascript/BlankPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="center">
+  <v-container class="center my-160">
     <v-btn
         dark
         large
@@ -25,8 +25,8 @@ export default {
 </script>
 
 <style scoped>
-.container {
-  margin-top: 160px;
+.my-160 {
+  margin: 160px auto;
 }
 
 p {

--- a/app/javascript/RegisteredPlayers.vue
+++ b/app/javascript/RegisteredPlayers.vue
@@ -58,6 +58,11 @@ export default {
 </script>
 
 <style scoped>
+/deep/ .v-application--wrap {
+  min-height: initial;
+  min-height: auto;
+}
+
 .v-tab {
   font-size: 1.4rem;
   font-weight: bold;


### PR DESCRIPTION
## 目的
登録済み選手一覧のレイアウトに不要な空白が入ってしまっていたため修正。

## 変更点
- 不要な空白の削除
- ブランク画面の際の更新時間の表示位置を調整

 ### 登録済の画面
![image](https://user-images.githubusercontent.com/59789739/104979742-6004bb00-5a48-11eb-8c6d-8ec34185109e.png)


 ### ブランク画面
![image](https://user-images.githubusercontent.com/59789739/104979540-e076ec00-5a47-11eb-85b8-7d44c64ee6bd.png)
