### PR TITLE
投手の表示項目に四球と死球を追加

### DIFF
--- a/app/javascript/RegisteredPitchers.vue
+++ b/app/javascript/RegisteredPitchers.vue
@@ -137,6 +137,16 @@ export default {
           firstSortType: 'desc'
         },
         {
+          label: '四球',
+          field: 'base_on_balls',
+          type: 'number'
+        },
+        {
+          label: '死球',
+          field: 'hit_by_pitch',
+          type: 'number'
+        },
+        {
           label: 'K/BB',
           field: 'strikeout_to_walk_ratio',
           type: 'number',

--- a/app/models/pitcher_score.rb
+++ b/app/models/pitcher_score.rb
@@ -15,6 +15,8 @@ class PitcherScore
     @number_of_save = scores[13]
     @hold_point = scores[12]
     @strikeouts_per_nine_innings = scores[19]
+    @base_on_balls = scores[20]
+    @hit_by_pitch = scores[21]
     @strikeout_to_walk_ratio = scores[27]
     @walks_and_hits_per_innings_pitched = scores[28]
   end
@@ -22,19 +24,21 @@ class PitcherScore
   def reflect_in_db
     pitcher = Pitcher.find_or_initialize_by(url: @url)
     pitcher.update!(number: @number,
-                   url: @url,
-                   name: @name,
-                   team_id: @team_id,
-                   earned_run_average: @earned_run_average,
-                   win: @win,
-                   lose: @lose,
-                   strikeout: @strikeout,
-                   innings_pitched: @innings_pitched,
-                   pitched: @pitched,
-                   number_of_save: @number_of_save,
-                   hold_point: @hold_point,
-                   strikeouts_per_nine_innings: @strikeouts_per_nine_innings,
-                   strikeout_to_walk_ratio: @strikeout_to_walk_ratio,
-                   walks_and_hits_per_innings_pitched: @walks_and_hits_per_innings_pitched)
+                    url: @url,
+                    name: @name,
+                    team_id: @team_id,
+                    earned_run_average: @earned_run_average,
+                    win: @win,
+                    lose: @lose,
+                    strikeout: @strikeout,
+                    innings_pitched: @innings_pitched,
+                    pitched: @pitched,
+                    number_of_save: @number_of_save,
+                    hold_point: @hold_point,
+                    strikeouts_per_nine_innings: @strikeouts_per_nine_innings,
+                    base_on_balls: @base_on_balls,
+                    hit_by_pitch: @hit_by_pitch,
+                    strikeout_to_walk_ratio: @strikeout_to_walk_ratio,
+                    walks_and_hits_per_innings_pitched: @walks_and_hits_per_innings_pitched)
   end
 end

--- a/app/views/api/v1/registered_players/index.json.jbuilder
+++ b/app/views/api/v1/registered_players/index.json.jbuilder
@@ -16,7 +16,7 @@ json.pitchers do
   json.array! @pitchers do |pitcher|
     json.extract! pitcher, :number, :url, :name, :earned_run_average, :win, :lose, :strikeout,
                   :innings_pitched, :pitched, :number_of_save, :hold_point, :strikeouts_per_nine_innings,
-                  :strikeout_to_walk_ratio, :walks_and_hits_per_innings_pitched
+                  :base_on_balls, :hit_by_pitch, :strikeout_to_walk_ratio, :walks_and_hits_per_innings_pitched
     json.pitcher_id pitcher.id
     json.team pitcher.team.name
     json.english_team_name pitcher.team.english_name

--- a/db/migrate/20210119022729_add_columns_to_pitchers.rb
+++ b/db/migrate/20210119022729_add_columns_to_pitchers.rb
@@ -1,0 +1,6 @@
+class AddColumnsToPitchers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pitchers, :base_on_balls, :string
+    add_column :pitchers, :hit_by_pitch, :string
+  end
+end

--- a/db/migrate/20210119022729_add_columns_to_pitchers.rb
+++ b/db/migrate/20210119022729_add_columns_to_pitchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddColumnsToPitchers < ActiveRecord::Migration[6.0]
   def change
     add_column :pitchers, :base_on_balls, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_12_045044) do
+ActiveRecord::Schema.define(version: 2021_01_19_022729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,8 @@ ActiveRecord::Schema.define(version: 2021_01_12_045044) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "url"
     t.bigint "team_id"
+    t.string "base_on_balls"
+    t.string "hit_by_pitch"
     t.index ["team_id"], name: "index_pitchers_on_team_id"
   end
 


### PR DESCRIPTION
## 目的
登録済み選手一覧の投手テーブルに、新たに四球と死球を追加する。

## 変更点
- DBのpitcherテーブルにbase_on_ballsカラムとhit_by_pitchカラムを追加
- スクレイピングで四球と死球のデータも取り出すように変更
- index.json.jbuilderに四球と死球の項目を追加
- registered_pitcherコンポーネントのテーブルに四球と死球の項目を追加

![image](https://user-images.githubusercontent.com/59789739/104987745-c219ec00-5a59-11eb-9aab-b57aeccabfae.png)
