### PR TITLE
選手名で登録のコンポーネントと登録済み選手コンポーネントを連動させる

### DIFF
--- a/app/javascript/PlayerSearch.vue
+++ b/app/javascript/PlayerSearch.vue
@@ -39,6 +39,7 @@
 <script>
 import {axiosClient} from './axios_client'
 import VueSimpleSuggest from 'vue-simple-suggest'
+import store from './store.js'
 
 export default {
   data() {
@@ -77,6 +78,7 @@ export default {
     registerProcessing(){
       this.registerPlayer().then(() => {
         this.successNotice()
+        store.commit('changeFlag')
       }).catch(() => {
         this.duplicateErrorNotice()
       }).finally(() => {

--- a/app/javascript/RegisteredPlayers.vue
+++ b/app/javascript/RegisteredPlayers.vue
@@ -25,6 +25,7 @@
 import RegisteredBatters from './RegisteredBatters'
 import RegisteredPitchers from './RegisteredPitchers'
 import BlankPage from './BlankPage'
+import store from './store'
 import {axiosClient} from './axios_client'
 
 export default {
@@ -33,6 +34,17 @@ export default {
       registeredPlayers: {},
       tab: null,
       snackbar: false
+    }
+  },
+  computed: {
+    updateFlag() {
+      return store.state.updateFlag
+    }
+  },
+  watch: {
+    updateFlag() {
+      this.fetchRegisteredPlayers()
+      this.$forceUpdate()
     }
   },
   components: {

--- a/app/javascript/store.js
+++ b/app/javascript/store.js
@@ -1,0 +1,15 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+
+Vue.use(Vuex)
+
+export default new Vuex.Store({
+  state: {
+    updateFlag: true
+  },
+  mutations: {
+    changeFlag (state) {
+      state.updateFlag = !state.updateFlag
+    }
+  }
+})

--- a/package.json
+++ b/package.json
@@ -2,13 +2,18 @@
   "name": "prospects_watcher",
   "private": true,
   "dependencies": {
+    "@mdi/font": "^5.8.55",
+    "@mdi/js": "^5.8.55",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",
     "axios": "^0.21.0",
     "element-ui": "^2.14.1",
+    "file-loader": "^6.2.0",
+    "material-design-icons-iconfont": "^6.1.0",
     "materialize-css": "^1.0.0",
+    "rails-ujs": "^5.2.4-4",
     "turbolinks": "^5.2.0",
     "vue": "^2.6.12",
     "vue-good-table": "^2.21.1",
@@ -16,11 +21,7 @@
     "vue-simple-suggest": "^1.10.3",
     "vue-template-compiler": "^2.6.12",
     "vuetify": "^2.4.2",
-    "@mdi/font": "^5.8.55",
-    "@mdi/js": "^5.8.55",
-    "file-loader": "^6.2.0",
-    "material-design-icons-iconfont": "^6.1.0",
-    "rails-ujs": "^5.2.4-4"
+    "vuex": "^3.6.0"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7585,6 +7585,11 @@ vuetify@^2.4.2:
   resolved "https://registry.npmjs.org/vuetify/-/vuetify-2.4.2.tgz"
   integrity sha512-8W1928Fv6GKwLiOThutYf2wtD5C9+vcCavlI8NT0YxNOVvluoL8xrep8mGGwDsCkay+4LzaAX92owKeNi3kpWg==
 
+vuex@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.6.0.tgz#95efa56a58f7607c135b053350833a09e01aa813"
+  integrity sha512-W74OO2vCJPs9/YjNjW8lLbj+jzT24waTo2KShI8jLvJW8OaIkgb3wuAMA7D+ZiUxDOx3ubwSZTaJBip9G8a3aQ==
+
 watchpack-chokidar2@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz"


### PR DESCRIPTION
## 目的
登録済み選手一覧のページを表示させているときにヘッダーの選手名で登録のフォームから登録を行うと、一度ページを更新しないと登録した選手が表示されないという挙動になっていた。
そのため、Vuexを使用して2つのコンポーネントを連動させるように実装した。

## 変更点
- Vuexの導入
- 選手名で登録を行った際にVuexのstateを変更する処理を追加
- RegisterPlayersコンポーネントでstateを監視し、変更があった際にデータの取得と再描画を行うように実装

[![Image from Gyazo](https://i.gyazo.com/a340b65786f2df19a5dd2a5f22e2bc9a.gif)](https://gyazo.com/a340b65786f2df19a5dd2a5f22e2bc9a)