### PR TITLE
投手の比較テーブルに四球と死球の項目を追加

### DIFF
--- a/app/javascript/ComparePitcherScoreTable.vue
+++ b/app/javascript/ComparePitcherScoreTable.vue
@@ -69,6 +69,24 @@
         </td>
       </tr>
       <tr>
+        <td :class="{ emphasis: isEmphasisInt(playerY['base_on_balls'], playerX['base_on_balls']) }">
+          {{playerX['base_on_balls']}}
+        </td>
+        <th>四球</th>
+        <td :class="{ emphasis: isEmphasisInt(playerX['base_on_balls'], playerY['base_on_balls']) }">
+          {{playerY['base_on_balls']}}
+        </td>
+      </tr>
+      <tr>
+        <td :class="{ emphasis: isEmphasisInt(playerY['hit_by_pitch'], playerX['hit_by_pitch']) }">
+          {{playerX['hit_by_pitch']}}
+        </td>
+        <th>死球</th>
+        <td :class="{ emphasis: isEmphasisInt(playerX['hit_by_pitch'], playerY['hit_by_pitch']) }">
+          {{playerY['hit_by_pitch']}}
+        </td>
+      </tr>
+      <tr>
         <td :class="{ emphasis: isEmphasisFloat(playerX['strikeout_to_walk_ratio'], playerY['strikeout_to_walk_ratio']) }">
           {{playerX['strikeout_to_walk_ratio']}}
         </td>


### PR DESCRIPTION
## 目的
#77 で投手の成績に四球と死球を追加した際に、比較機能の項目に四球と死球を追加し忘れていたため修正。

## 変更点
- 投手の1対1比較テーブルに四球と死球の項目を追加


![image](https://user-images.githubusercontent.com/59789739/105926357-31f52b80-6085-11eb-85ca-8c60d697a7c2.png)
