### PR TITLE
登録済み選手テーブルのsort_flagの変数名をparticipation_flagに変更

### DIFF
--- a/app/javascript/RegisteredBatters.vue
+++ b/app/javascript/RegisteredBatters.vue
@@ -9,7 +9,7 @@
       :sort-options="{
         enabled: true,
         initialSortBy: [
-            {field: 'sort_flag', type: 'desc'},
+            {field: 'participation_flag', type: 'desc'},
             {field: 'at_bat', type: 'desc'}
         ]
       }"
@@ -161,7 +161,7 @@ export default {
           type: 'number'
         },
         {
-          field: 'sort_flag',
+          field: 'participation_flag',
           type: 'number',
           hidden: 'true'
         }

--- a/app/javascript/RegisteredPitchers.vue
+++ b/app/javascript/RegisteredPitchers.vue
@@ -9,7 +9,7 @@
       :sort-options="{
         enabled: true,
         initialSortBy: [
-            {field: 'sort_flag', type: 'desc'},
+            {field: 'participation_flag', type: 'desc'},
             {field: 'innings_pitched', type: 'desc'}
         ]
       }"
@@ -158,7 +158,7 @@ export default {
           type: 'number'
         },
         {
-          field: 'sort_flag',
+          field: 'participation_flag',
           type: 'number',
           hidden: true
         }


### PR DESCRIPTION
## 目的
RegisteredBatters/Pitchersコンポーネントの変数sort_flagの名前が抽象的なので修正する。

## 変更点
- sort_flagをparticipation_flagに変更