### PR TITLE
widthの%での指定をpxでの指定に修正

### DIFF
--- a/app/javascript/css/application.css
+++ b/app/javascript/css/application.css
@@ -24,6 +24,6 @@
 }
 
 .devise-form {
-    width: 40%;
+    width: 560px;
     margin: auto;
 }


### PR DESCRIPTION
## 目的
ログインページ、新規登録ページ、ユーザー情報編集ページのwidthの指定を%で行っていたためpxでの絶対値での指定に修正。

## 変更点
- devise-formクラスの要素の幅指定をpxに変更