### PR TITLE
3桁で0から始まる背番号の選手を2桁の背番号より後に表示されるように変更

### DIFF
--- a/app/models/players_data_formatter.rb
+++ b/app/models/players_data_formatter.rb
@@ -23,7 +23,13 @@ class PlayersDataFormatter
 
   private
   def sort_by_number(players)
-    players.sort_by { |player| player.number.to_i }
+    players.sort_by do |player|
+      if player.number.size == 3 && player.number[0] == "0"
+        player.number.sub("0", "1").to_i
+      else
+        player.number.to_i
+      end
+    end
   end
 
   def divide_by_team(players, team)


### PR DESCRIPTION
## 目的
巨人やヤクルトのように"006"のような0から始まる背番号を育成選手に付けている球団は、選手一覧で支配下選手に混じって育成選手が表示されてしまい見づらい。
育成選手の成績は表示されないので、表示順は後ろに固定したかった。