### PR TITLE
選手名に入ってしまう不要な空白の削除

### DIFF
--- a/app/models/batter_score.rb
+++ b/app/models/batter_score.rb
@@ -4,7 +4,7 @@ class BatterScore
   def initialize(scores, team_id)
     @number = scores[0]
     @url = scores[1]
-    @name = scores[2]
+    @name = scores[2].strip
     @team_id = team_id
     @batting_average = scores[3]
     @plate_appearance = scores[5]

--- a/app/models/pitcher_score.rb
+++ b/app/models/pitcher_score.rb
@@ -4,7 +4,7 @@ class PitcherScore
   def initialize(scores, team_id)
     @number = scores[0]
     @url = scores[1]
-    @name = scores[2]
+    @name = scores[2].strip
     @team_id = team_id
     @earned_run_average = scores[3]
     @win = scores[9]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,7 @@ Team.create!(
     },
     {
       name: '西武',
-      formal_name: '埼玉西部ライオンズ',
+      formal_name: '埼玉西武ライオンズ',
       ranking: 3,
       league: :pacific,
       url_id: 7,


### PR DESCRIPTION
close #105 

## 目的
Yahoo側のHTMLが原因で野手名に不要な空白が入ってしまっているため、空白削除の処理を追加する。
投手側も同様の問題が起きる可能性があるため修正する。

## 変更点
- batter_scoreおよびpitcher_scoreにstripを追加