### PR TITLE
スクレイピング時に必ずupdated_atを更新するように修正

### DIFF
--- a/app/models/batter_score.rb
+++ b/app/models/batter_score.rb
@@ -42,5 +42,6 @@ class BatterScore
                   scoring_position_batting_average: @scoring_position_batting_average,
                   strikeout: @strikeout,
                   error: @error)
+    batter.touch
   end
 end

--- a/app/models/pitcher_score.rb
+++ b/app/models/pitcher_score.rb
@@ -40,5 +40,6 @@ class PitcherScore
                     hit_by_pitch: @hit_by_pitch,
                     strikeout_to_walk_ratio: @strikeout_to_walk_ratio,
                     walks_and_hits_per_innings_pitched: @walks_and_hits_per_innings_pitched)
+    pitcher.touch
   end
 end


### PR DESCRIPTION
## 目的
引退やMLB等の他リーグへの移籍をした選手を判別できるように、スクレイピングできた選手＝NPB所属選手の場合は、更新項目がない場合でもupdated_atを更新するように変更。

## 変更点
- PitcherおよびBatterのデータ更新処理に、touchを差し込む