### PR TITLE
Rspecを導入

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.7
+FROM --platform=linux/amd64 ruby:2.7.7
 ENV LANG C.UTF-8
 
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
@@ -6,6 +6,14 @@ RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && apt-get install -y yarn
+
+# Chromeをインストール
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
+    && apt-get update \
+    && apt-get install -y apt-transport-https \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable
 
 RUN mkdir /prospects_watcher
 WORKDIR /prospects_watcher

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
 # Use SCSS for stylesheets
+gem 'sassc', '2.1.0'
 gem 'sass-rails', '>= 6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 4.0'

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'rspec-rails'
+  gem 'factory_bot'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'rspec-rails'
-  gem 'factory_bot'
+  gem 'factory_bot_rails'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,6 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
-  gem 'webdrivers'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
     erubi (1.12.0)
+    factory_bot (6.3.0)
+      activesupport (>= 5.0.0)
     ffi (1.13.1)
     foreman (0.87.2)
     globalid (1.1.0)
@@ -304,6 +306,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   devise
+  factory_bot
   foreman
   html2slim
   jbuilder (~> 2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,8 +86,11 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
     erubi (1.12.0)
-    factory_bot (6.3.0)
+    factory_bot (6.2.1)
       activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     ffi (1.15.5)
     foreman (0.87.2)
     globalid (1.1.0)
@@ -306,7 +309,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   devise
-  factory_bot
+  factory_bot_rails
   foreman
   html2slim
   jbuilder (~> 2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     erubi (1.12.0)
     factory_bot (6.3.0)
       activesupport (>= 5.0.0)
-    ffi (1.13.1)
+    ffi (1.15.5)
     foreman (0.87.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -237,7 +237,7 @@ GEM
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
+    sassc (2.1.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -324,6 +324,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   sass-rails (>= 6)
+  sassc (= 2.1.0)
   selenium-webdriver
   slim-rails
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,10 +285,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (4.4.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (4.3.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -333,7 +329,6 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
-  webdrivers
   webpacker (~> 4.0)
 
 RUBY VERSION

--- a/app/controllers/registered_players_controller.rb
+++ b/app/controllers/registered_players_controller.rb
@@ -6,6 +6,6 @@ class RegisteredPlayersController < ApplicationController
   def index
     @favorite_batters = current_user.favorite_batters.all
     @favorite_pitchers = current_user.favorite_pitchers.all
-    @data_update_at = ScrapingLog.last.updated_at
+    @data_update_at = ScrapingLog.last&.updated_at
   end
 end

--- a/app/views/registered_players/index.html.slim
+++ b/app/views/registered_players/index.html.slim
@@ -1,4 +1,4 @@
 #js-registered-players
 .right-align
   span
-    = "#{l @data_update_at}更新"
+    = "#{l @data_update_at}更新" if @data_update_at

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,8 +21,8 @@ default: &default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   user: prospects_watcher
-  password: password
-  host: db
+  password: <%= ENV['POSTGRES_USER'] || '' %>
+  host: <%= ENV['POSTGRES_HOST'] || 'localhost' %>
 
 development:
   <<: *default

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,4 +48,6 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,13 +19,14 @@ services:
       - "3000:3000"
     depends_on:
       - db
+    environment:
+      - "SELENIUM_DRIVER_URL=http://selenium_chrome:4444/wd/hub"
   webpacker:
     build: .
     environment:
       NODE_ENV: development
       RAILS_ENV: development
       WEBPACKER_DEV_SERVER_HOST: 0.0.0.0
-      SELENIUM_DRIVER_URL: http://selenium_chrome:4444/wd/hub
 
     command: "bin/webpack-dev-server"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     ports:
       - '5433:5432'
   web: &app_base
+    platform: linux/x86_64
     build: .
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     volumes:
@@ -24,6 +25,8 @@ services:
       NODE_ENV: development
       RAILS_ENV: development
       WEBPACKER_DEV_SERVER_HOST: 0.0.0.0
+      SELENIUM_DRIVER_URL: http://selenium_chrome:4444/wd/hub
+
     command: "bin/webpack-dev-server"
     ports:
       - "3035:3035"
@@ -32,5 +35,7 @@ services:
     tty: false
     stdin_open: false
 
+  selenium_chrome:
+    image: selenium/standalone-chrome-debug
 volumes:
   db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - "db-data:/var/lib/postgresql/data"
     ports:
-      - '5433:5432'
+      - '5432:5432'
   web: &app_base
     platform: linux/x86_64
     build: .

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user do
+    email { 'sample@example.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,9 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'capybara/rspec'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -15,6 +15,15 @@ RSpec.configure do |config|
     end
   else
     config.before(:each, type: :system) do
+      Capybara.register_driver :selenium_chrome_headless do |app|
+        options = Selenium::WebDriver::Chrome::Options.new
+        options.add_argument('--headless')
+        options.add_argument('--no-sandbox')
+        options.add_argument('--disable-gpu')
+        options.add_argument('--window-size=1280,1024')
+
+        Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+      end
       driven_by :selenium_chrome_headless
     end
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'capybara/rspec'
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :selenium, using: :headless_chrome, options: {
       browser: :remote,
-      url: ENV.fetch("SELENIUM_DRIVER_URL"),
+      url: ENV.fetch('SELENIUM_DRIVER_URL'),
       desired_capabilities: :chrome
     }
     Capybara.server_host = 'web'

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,13 +3,19 @@
 require 'capybara/rspec'
 
 RSpec.configure do |config|
-  config.before(:each, type: :system) do
-    driven_by :selenium, using: :headless_chrome, options: {
-      browser: :remote,
-      url: ENV.fetch('SELENIUM_DRIVER_URL'),
-      desired_capabilities: :chrome
-    }
-    Capybara.server_host = 'web'
-    Capybara.app_host="http://#{Capybara.server_host}"
+  if ENV['SELENIUM_DRIVER_URL']
+    config.before(:each, type: :system) do
+      driven_by :selenium, using: :headless_chrome, options: {
+        browser: :remote,
+        url: ENV.fetch('SELENIUM_DRIVER_URL'),
+        desired_capabilities: :chrome
+      }
+      Capybara.server_host = 'web'
+      Capybara.app_host="http://#{Capybara.server_host}"
+    end
+  else
+    config.before(:each, type: :system) do
+      driven_by :selenium_chrome_headless
+    end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,13 @@
+require 'capybara/rspec'
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome, options: {
+      browser: :remote,
+      url: ENV.fetch("SELENIUM_DRIVER_URL"),
+      desired_capabilities: :chrome
+    }
+    Capybara.server_host = 'web'
+    Capybara.app_host="http://#{Capybara.server_host}"
+  end
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -26,10 +26,20 @@ RSpec.describe 'ログインページ', type: :system do
       fill_in 'Eメール', with: 'tanaka@example.com'
       fill_in 'パスワード', with: 'password'
       click_on 'ログイン'
-      save_screenshot 'hoge.png'
     end
   end
 
   describe :log_out do
+    let!(:user) { create(:user, email: 'tanaka@example.com', confirmed_at: Time.zone.now) }
+
+    before do
+      sign_in user
+      visit root_path
+    end
+
+    it 'ログアウトが行えること' do
+      click_on 'ログアウト'
+      expect(page).to have_content 'アカウント登録もしくはログインしてください。'
+    end
   end
 end

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'ログインページ', type: :system do
@@ -17,9 +19,14 @@ RSpec.describe 'ログインページ', type: :system do
   end
 
   describe :login do
+    let!(:user) { create(:user, email: 'tanaka@example.com', confirmed_at: Time.zone.now) }
     before { visit new_user_session_path }
 
     it 'ログインが行えること' do
+      fill_in 'Eメール', with: 'tanaka@example.com'
+      fill_in 'パスワード', with: 'password'
+      click_on 'ログイン'
+      save_screenshot 'hoge.png'
     end
   end
 

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'ログインページ', type: :system do
+  describe :sign_up do
+    before { visit new_user_registration_path }
+
+    it '新規ユーザー作成が行えること' do
+      fill_in 'Eメール', with: 'kikuchi@example.com'
+      fill_in 'パスワード', with: 'password'
+      fill_in 'パスワード（確認用）', with: 'password'
+      click_on 'アカウント登録'
+      # ログイン画面に遷移
+      # TODO:メールを送った旨のメッセージが出ないため対応する
+      expect(page).to have_content 'パスワードを忘れましたか？'
+      expect(User.last.email).to eq 'kikuchi@example.com'
+    end
+  end
+
+  describe :login do
+    before { visit new_user_session_path }
+
+    it 'ログインが行えること' do
+    end
+  end
+
+  describe :log_out do
+  end
+end


### PR DESCRIPTION
## 概要
RspecのSystem specを実行できる環境を整える。

## 技術的な変更点
- Dockerfileにgoogle chrome stableのインストールコマンドを記載
    - M1 Mac上ではarm64のchromeをインストールしようとしてエラーとなるため、Dockerのコンテナの実行環境をamd64に固定
    - docker-compose.ymlにselenium_chromeコンテナの設定を記載
- docker環境でテストを動かすためにgem webdriverを削除
- capybara利用のための設定を追加
- ユーザー新規作成のテストを追加