### PR TITLE
ユニットテストおよびリクエストスペックの追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  rubocop:
+    name: RuboCop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run RuboCop
+        run: bundle exec rubocop
+
+  rspec:
+    name: RSpec
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      POSTGRES_HOST: 127.0.0.1
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
+          cache: yarn
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Set up database
+        run: bin/rails db:prepare
+
+      - name: Run RSpec
+        run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Set up database
-        run: bin/rails db:prepare
+        run: bin/rails db:create db:schema:load
 
       - name: Run RSpec
         run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          rubygems: latest
           bundler-cache: true
 
       - name: Run RuboCop
@@ -51,6 +52,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          rubygems: latest
           bundler-cache: true
 
       - name: Set up Node

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
-  gem 'selenium-webdriver'
+  gem 'selenium-webdriver', '~> 4.16'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'rspec-rails'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    base64 (0.3.0)
     bcrypt (3.1.20)
     bindex (0.8.1)
     bootsnap (1.18.3)
@@ -121,6 +122,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -212,8 +214,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     retryable (3.0.5)
-    rexml (3.3.1)
-      strscan
+    rexml (3.4.4)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.1)
@@ -253,7 +254,7 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    rubyzip (2.3.2)
+    rubyzip (2.4.1)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -264,7 +265,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.9.0)
+    selenium-webdriver (4.26.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -288,7 +291,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    strscan (3.1.0)
     temple (0.10.3)
     thor (1.3.1)
     thread_safe (0.3.6)
@@ -349,7 +351,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (>= 6)
   sassc
-  selenium-webdriver
+  selenium-webdriver (~> 4.16)
   slim-rails
   spring
   spring-commands-rspec

--- a/spec/factories/favorite_batters.rb
+++ b/spec/factories/favorite_batters.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :favorite_batter do
+    association :user
+    association :batter
+  end
+end

--- a/spec/factories/favorite_pitchers.rb
+++ b/spec/factories/favorite_pitchers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :favorite_pitcher do
+    association :user
+    association :pitcher
+  end
+end

--- a/spec/models/batter_score_spec.rb
+++ b/spec/models/batter_score_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BatterScore, type: :model do
+  let(:team) { create(:team) }
+
+  let(:scores) do
+    Array.new(28).tap do |s|
+      s[1]  = '51'
+      s[2]  = 'https://baseball.yahoo.co.jp/npb/player/1234/top'
+      s[3]  = '  鈴木 誠也  '
+      s[4]  = '0.317'
+      s[6]  = '542'
+      s[7]  = '435'
+      s[8]  = '138'
+      s[11] = '38'
+      s[13] = '88'
+      s[15] = '99'
+      s[16] = '87'
+      s[17] = '6'
+      s[20] = '9'
+      s[23] = '0.433'
+      s[25] = '1.072'
+      s[26] = '0.295'
+      s[27] = '3'
+    end
+  end
+
+  subject(:batter_score) { described_class.new(scores, team.id) }
+
+  describe '#initialize' do
+    it '背番号を正しく取得する' do
+      expect(batter_score.instance_variable_get(:@number)).to eq '51'
+    end
+
+    it 'URLを正しく取得する' do
+      expect(batter_score.instance_variable_get(:@url)).to eq 'https://baseball.yahoo.co.jp/npb/player/1234/top'
+    end
+
+    it '選手名の前後の空白を除去する' do
+      expect(batter_score.instance_variable_get(:@name)).to eq '鈴木 誠也'
+    end
+
+    it 'team_idを正しく取得する' do
+      expect(batter_score.instance_variable_get(:@team_id)).to eq team.id
+    end
+
+    it '打率(batting_average)をインデックス4から取得する' do
+      expect(batter_score.instance_variable_get(:@batting_average)).to eq '0.317'
+    end
+
+    it '打席数(plate_appearance)をインデックス6から取得する' do
+      expect(batter_score.instance_variable_get(:@plate_appearance)).to eq '542'
+    end
+
+    it '打数(at_bat)をインデックス7から取得する' do
+      expect(batter_score.instance_variable_get(:@at_bat)).to eq '435'
+    end
+
+    it '安打数(hits)をインデックス8から取得する' do
+      expect(batter_score.instance_variable_get(:@hits)).to eq '138'
+    end
+
+    it '本塁打(home_run)をインデックス11から取得する' do
+      expect(batter_score.instance_variable_get(:@home_run)).to eq '38'
+    end
+
+    it '打点(runs_batted_in)をインデックス13から取得する' do
+      expect(batter_score.instance_variable_get(:@runs_batted_in)).to eq '88'
+    end
+
+    it '三振(strikeout)をインデックス15から取得する' do
+      expect(batter_score.instance_variable_get(:@strikeout)).to eq '99'
+    end
+
+    it '四球(walks)をインデックス16から取得する' do
+      expect(batter_score.instance_variable_get(:@walks)).to eq '87'
+    end
+
+    it '死球(hit_by_pitch)をインデックス17から取得する' do
+      expect(batter_score.instance_variable_get(:@hit_by_pitch)).to eq '6'
+    end
+
+    it '盗塁(stolen_base)をインデックス20から取得する' do
+      expect(batter_score.instance_variable_get(:@stolen_base)).to eq '9'
+    end
+
+    it '出塁率(on_base_percentage)をインデックス23から取得する' do
+      expect(batter_score.instance_variable_get(:@on_base_percentage)).to eq '0.433'
+    end
+
+    it 'OPS(on_base_plus_slugging)をインデックス25から取得する' do
+      expect(batter_score.instance_variable_get(:@on_base_plus_slugging)).to eq '1.072'
+    end
+
+    it '得点圏打率(scoring_position_batting_average)をインデックス26から取得する' do
+      expect(batter_score.instance_variable_get(:@scoring_position_batting_average)).to eq '0.295'
+    end
+
+    it 'エラー(error)をインデックス27から取得する' do
+      expect(batter_score.instance_variable_get(:@error)).to eq '3'
+    end
+  end
+
+  describe '#reflect_in_db' do
+    context '該当URLのBatterが存在しない場合' do
+      it '新規レコードを作成する' do
+        expect { batter_score.reflect_in_db }.to change(Batter, :count).by(1)
+      end
+
+      it '正しい属性でレコードを作成する' do
+        batter_score.reflect_in_db
+        batter = Batter.find_by(url: 'https://baseball.yahoo.co.jp/npb/player/1234/top')
+        expect(batter).to have_attributes(
+          number: '51',
+          name: '鈴木 誠也',
+          team_id: team.id,
+          batting_average: '0.317',
+          plate_appearance: '542',
+          at_bat: '435',
+          hits: '138',
+          home_run: '38',
+          runs_batted_in: '88',
+          strikeout: '99',
+          walks: '87',
+          hit_by_pitch: '6',
+          stolen_base: '9',
+          on_base_percentage: '0.433',
+          on_base_plus_slugging: '1.072',
+          scoring_position_batting_average: '0.295',
+          error: '3'
+        )
+      end
+    end
+
+    context '該当URLのBatterが既に存在する場合' do
+      let!(:existing_batter) do
+        create(:batter, url: 'https://baseball.yahoo.co.jp/npb/player/1234/top', team: team, name: '旧名前', home_run: '0')
+      end
+
+      it 'レコードを新規作成せず既存レコードを更新する' do
+        expect { batter_score.reflect_in_db }.not_to change(Batter, :count)
+      end
+
+      it '既存レコードの値を上書きする' do
+        batter_score.reflect_in_db
+        expect(existing_batter.reload).to have_attributes(
+          name: '鈴木 誠也',
+          home_run: '38'
+        )
+      end
+
+      it 'updated_atを更新する' do
+        original_time = 1.day.ago
+        existing_batter.update_column(:updated_at, original_time)
+        batter_score.reflect_in_db
+        expect(existing_batter.reload.updated_at).to be > original_time
+      end
+    end
+  end
+end

--- a/spec/models/pitcher_score_spec.rb
+++ b/spec/models/pitcher_score_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PitcherScore, type: :model do
+  let(:team) { create(:team) }
+
+  let(:scores) do
+    Array.new(29).tap do |s|
+      s[0]  = '18'
+      s[1]  = 'https://baseball.yahoo.co.jp/npb/player/5678/top'
+      s[2]  = '  前田 健太  '
+      s[3]  = '2.09'
+      s[4]  = '29'
+      s[9]  = '15'
+      s[10] = '8'
+      s[12] = '0'
+      s[13] = '0'
+      s[15] = '206.1'
+      s[18] = '175'
+      s[19] = '7.63'
+      s[20] = '41'
+      s[21] = '6'
+      s[27] = '4.27'
+      s[28] = '1.01'
+    end
+  end
+
+  subject(:pitcher_score) { described_class.new(scores, team.id) }
+
+  describe '#initialize' do
+    it '背番号をインデックス0から取得する' do
+      expect(pitcher_score.instance_variable_get(:@number)).to eq '18'
+    end
+
+    it 'URLをインデックス1から取得する' do
+      expect(pitcher_score.instance_variable_get(:@url)).to eq 'https://baseball.yahoo.co.jp/npb/player/5678/top'
+    end
+
+    it '選手名の前後の空白を除去する' do
+      expect(pitcher_score.instance_variable_get(:@name)).to eq '前田 健太'
+    end
+
+    it 'team_idを正しく取得する' do
+      expect(pitcher_score.instance_variable_get(:@team_id)).to eq team.id
+    end
+
+    it '防御率(earned_run_average)をインデックス3から取得する' do
+      expect(pitcher_score.instance_variable_get(:@earned_run_average)).to eq '2.09'
+    end
+
+    it '登板数(pitched)をインデックス4から取得する' do
+      expect(pitcher_score.instance_variable_get(:@pitched)).to eq '29'
+    end
+
+    it '勝利(win)をインデックス9から取得する' do
+      expect(pitcher_score.instance_variable_get(:@win)).to eq '15'
+    end
+
+    it '敗北(lose)をインデックス10から取得する' do
+      expect(pitcher_score.instance_variable_get(:@lose)).to eq '8'
+    end
+
+    it 'ホールドポイント(hold_point)をインデックス12から取得する' do
+      expect(pitcher_score.instance_variable_get(:@hold_point)).to eq '0'
+    end
+
+    it 'セーブ数(number_of_save)をインデックス13から取得する' do
+      expect(pitcher_score.instance_variable_get(:@number_of_save)).to eq '0'
+    end
+
+    it '投球回(innings_pitched)をインデックス15から取得する' do
+      expect(pitcher_score.instance_variable_get(:@innings_pitched)).to eq '206.1'
+    end
+
+    it '奪三振(strikeout)をインデックス18から取得する' do
+      expect(pitcher_score.instance_variable_get(:@strikeout)).to eq '175'
+    end
+
+    it '9回あたり奪三振(strikeouts_per_nine_innings)をインデックス19から取得する' do
+      expect(pitcher_score.instance_variable_get(:@strikeouts_per_nine_innings)).to eq '7.63'
+    end
+
+    it '与四球(base_on_balls)をインデックス20から取得する' do
+      expect(pitcher_score.instance_variable_get(:@base_on_balls)).to eq '41'
+    end
+
+    it '与死球(hit_by_pitch)をインデックス21から取得する' do
+      expect(pitcher_score.instance_variable_get(:@hit_by_pitch)).to eq '6'
+    end
+
+    it '奪三振/与四球(strikeout_to_walk_ratio)をインデックス27から取得する' do
+      expect(pitcher_score.instance_variable_get(:@strikeout_to_walk_ratio)).to eq '4.27'
+    end
+
+    it 'WHIP(walks_and_hits_per_innings_pitched)をインデックス28から取得する' do
+      expect(pitcher_score.instance_variable_get(:@walks_and_hits_per_innings_pitched)).to eq '1.01'
+    end
+  end
+
+  describe '#reflect_in_db' do
+    context '該当URLのPitcherが存在しない場合' do
+      it '新規レコードを作成する' do
+        expect { pitcher_score.reflect_in_db }.to change(Pitcher, :count).by(1)
+      end
+
+      it '正しい属性でレコードを作成する' do
+        pitcher_score.reflect_in_db
+        pitcher = Pitcher.find_by(url: 'https://baseball.yahoo.co.jp/npb/player/5678/top')
+        expect(pitcher).to have_attributes(
+          number: '18',
+          name: '前田 健太',
+          team_id: team.id,
+          earned_run_average: '2.09',
+          pitched: '29',
+          win: '15',
+          lose: '8',
+          hold_point: '0',
+          number_of_save: '0',
+          innings_pitched: '206.1',
+          strikeout: '175',
+          strikeouts_per_nine_innings: '7.63',
+          base_on_balls: '41',
+          hit_by_pitch: '6',
+          strikeout_to_walk_ratio: '4.27',
+          walks_and_hits_per_innings_pitched: '1.01'
+        )
+      end
+    end
+
+    context '該当URLのPitcherが既に存在する場合' do
+      let!(:existing_pitcher) do
+        create(:pitcher, url: 'https://baseball.yahoo.co.jp/npb/player/5678/top', team: team, name: '旧名前', win: '0')
+      end
+
+      it 'レコードを新規作成せず既存レコードを更新する' do
+        expect { pitcher_score.reflect_in_db }.not_to change(Pitcher, :count)
+      end
+
+      it '既存レコードの値を上書きする' do
+        pitcher_score.reflect_in_db
+        expect(existing_pitcher.reload).to have_attributes(
+          name: '前田 健太',
+          win: '15'
+        )
+      end
+
+      it 'updated_atを更新する' do
+        original_time = 1.day.ago
+        existing_pitcher.update_column(:updated_at, original_time)
+        pitcher_score.reflect_in_db
+        expect(existing_pitcher.reload.updated_at).to be > original_time
+      end
+    end
+  end
+end

--- a/spec/models/players_data_formatter_spec.rb
+++ b/spec/models/players_data_formatter_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PlayersDataFormatter, type: :model do
+  let(:central_team) { create(:team, name: '広島', formal_name: '広島東洋カープ', english_name: 'carp', league: :central) }
+  let(:pacific_team) { create(:team, name: '福岡', formal_name: '福岡ソフトバンクホークス', english_name: 'hawks', league: :pacific, url_id: 1, ranking: 1) }
+
+  describe '#run' do
+    context 'チームが1つも存在しない場合' do
+      subject(:result) { described_class.new([], [], []).run }
+
+      it 'central/pacificキーを持つハッシュを返す' do
+        expect(result).to eq({ central: [], pacific: [] })
+      end
+    end
+
+    context 'セ・リーグのチームのみ存在する場合' do
+      let!(:batter) { create(:batter, team: central_team, number: '1') }
+      let!(:pitcher) { create(:pitcher, team: central_team, number: '18') }
+
+      subject(:result) do
+        described_class.new([central_team], Batter.all, Pitcher.all).run
+      end
+
+      it 'centralキーにチーム情報を格納する' do
+        expect(result[:central].length).to eq 1
+      end
+
+      it 'pacificキーは空配列のまま' do
+        expect(result[:pacific]).to be_empty
+      end
+
+      it 'チームの名称情報が含まれる' do
+        team_data = result[:central].first
+        expect(team_data).to include(
+          name: '広島',
+          formal_name: '広島東洋カープ',
+          english_team_name: 'carp'
+        )
+      end
+
+      it 'battersキーに該当チームの打者が含まれる' do
+        expect(result[:central].first[:batters]).to include(batter)
+      end
+
+      it 'pitchersキーに該当チームの投手が含まれる' do
+        expect(result[:central].first[:pitchers]).to include(pitcher)
+      end
+    end
+
+    context 'セ・リーグとパ・リーグのチームが混在する場合' do
+      let!(:central_batter) { create(:batter, team: central_team, number: '1') }
+      let!(:pacific_batter) { create(:batter, team: pacific_team, number: '3', url: 'https://pacific.example.com') }
+
+      subject(:result) do
+        described_class.new([central_team, pacific_team], Batter.all, Pitcher.all).run
+      end
+
+      it 'centralキーにセ・リーグのチームのみ格納する' do
+        expect(result[:central].map { |t| t[:name] }).to contain_exactly('広島')
+      end
+
+      it 'pacificキーにパ・リーグのチームのみ格納する' do
+        expect(result[:pacific].map { |t| t[:name] }).to contain_exactly('福岡')
+      end
+
+      it 'セ・リーグの打者はセ・リーグのチームにのみ含まれる' do
+        expect(result[:central].first[:batters]).to include(central_batter)
+        expect(result[:pacific].first[:batters]).not_to include(central_batter)
+      end
+
+      it 'パ・リーグの打者はパ・リーグのチームにのみ含まれる' do
+        expect(result[:pacific].first[:batters]).to include(pacific_batter)
+        expect(result[:central].first[:batters]).not_to include(pacific_batter)
+      end
+    end
+  end
+
+  describe '#sort_by_number (private)' do
+    subject(:formatter) { described_class.new([], [], []) }
+
+    def players_with_numbers(*numbers)
+      numbers.map do |num|
+        create(:batter, team: central_team, number: num, url: "https://example.com/#{num}")
+      end
+    end
+
+    it '通常の背番号を数値順にソートする' do
+      players = players_with_numbers('10', '1', '50', '3')
+      sorted = formatter.send(:sort_by_number, players)
+      expect(sorted.map(&:number)).to eq %w[1 3 10 50]
+    end
+
+    it '3桁の通常番号(100以上)を正しくソートする' do
+      players = players_with_numbers('120', '3', '100')
+      sorted = formatter.send(:sort_by_number, players)
+      expect(sorted.map(&:number)).to eq %w[3 100 120]
+    end
+
+    context '先頭が0の3桁番号（例: 001, 010）の特殊ソート' do
+      it '001は101として扱い、100番台の中にソートされる' do
+        players = players_with_numbers('99', '001', '100')
+        sorted = formatter.send(:sort_by_number, players)
+        expect(sorted.map(&:number)).to eq %w[99 100 001]
+      end
+
+      it '010は110として扱い、100番台の中にソートされる' do
+        players = players_with_numbers('99', '010', '105')
+        sorted = formatter.send(:sort_by_number, players)
+        expect(sorted.map(&:number)).to eq %w[99 105 010]
+      end
+
+      it '001と010が混在する場合、001(→101)が010(→110)より前にソートされる' do
+        players = players_with_numbers('010', '001')
+        sorted = formatter.send(:sort_by_number, players)
+        expect(sorted.map(&:number)).to eq %w[001 010]
+      end
+    end
+
+    it '選手が0人の場合、空配列を返す' do
+      expect(formatter.send(:sort_by_number, [])).to eq []
+    end
+  end
+
+  describe '#divide_by_team (private)' do
+    subject(:formatter) { described_class.new([], [], []) }
+
+    let!(:central_batter1) { create(:batter, team: central_team, number: '1', url: 'https://example.com/1') }
+    let!(:central_batter2) { create(:batter, team: central_team, number: '2', url: 'https://example.com/2') }
+    let!(:pacific_batter)  { create(:batter, team: pacific_team,  number: '3', url: 'https://example.com/3') }
+
+    it '指定チームの選手のみを返す' do
+      result = formatter.send(:divide_by_team, Batter.all, central_team)
+      expect(result).to contain_exactly(central_batter1, central_batter2)
+    end
+
+    it '他チームの選手は含まれない' do
+      result = formatter.send(:divide_by_team, Batter.all, central_team)
+      expect(result).not_to include(pacific_batter)
+    end
+
+    it '該当チームの選手が存在しない場合、空配列を返す' do
+      other_team = create(:team, name: '他球団', formal_name: '他球団', english_name: 'other', league: :central, url_id: 99, ranking: 6)
+      result = formatter.send(:divide_by_team, Batter.all, other_team)
+      expect(result).to be_empty
+    end
+  end
+end

--- a/spec/models/score_scraper_spec.rb
+++ b/spec/models/score_scraper_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ScoreScraper, type: :model do
+  let(:url) { 'https://baseball.yahoo.co.jp/npb/teams/6/memberlist' }
+  let(:charset) { 'utf-8' }
+  let(:mock_file) { double('http_response', charset: charset, read: html_content) }
+
+  before do
+    allow(URI).to receive(:open).with(url).and_yield(mock_file)
+  end
+
+  subject(:scraper) { described_class.new(url) }
+
+  def build_table(rows_html)
+    "<html><body><table id='js-playerTable'>#{rows_html}</table></body></html>"
+  end
+
+  describe '#scrape' do
+    context 'リンクを含むセルがある場合' do
+      let(:html_content) do
+        build_table(<<~HTML)
+          <tr>
+            <td><a href="/npb/player/1/top">鈴木 誠也</a></td>
+            <td>0.317</td>
+          </tr>
+        HTML
+      end
+
+      it 'hrefとテキストの両方をデータに含める' do
+        result = scraper.scrape
+        expect(result.first).to include('/npb/player/1/top', '鈴木 誠也', '0.317')
+      end
+
+      it 'hrefがテキストより先にデータに追加される' do
+        result = scraper.scrape
+        href_index = result.first.index('/npb/player/1/top')
+        text_index = result.first.index('鈴木 誠也')
+        expect(href_index).to be < text_index
+      end
+    end
+
+    context 'リンクを含まないセルのみの場合' do
+      let(:html_content) do
+        build_table(<<~HTML)
+          <tr>
+            <td>18</td>
+            <td>2.09</td>
+          </tr>
+        HTML
+      end
+
+      it 'テキストのみをデータに含める' do
+        result = scraper.scrape
+        expect(result.first).to eq %w[18 2.09]
+      end
+    end
+
+    context 'テキストに改行が含まれる場合' do
+      let(:html_content) do
+        build_table(<<~HTML)
+          <tr>
+            <td>前田\n健太</td>
+          </tr>
+        HTML
+      end
+
+      it '改行を除去する' do
+        result = scraper.scrape
+        expect(result.first.first).to eq '前田健太'
+      end
+    end
+
+    context 'テキストの左側に空白がある場合' do
+      let(:html_content) do
+        build_table(<<~HTML)
+          <tr>
+            <td>   先頭空白</td>
+          </tr>
+        HTML
+      end
+
+      it '左側の空白を除去する' do
+        result = scraper.scrape
+        expect(result.first.first).to eq '先頭空白'
+      end
+    end
+
+    context 'tdが存在しない空行がある場合' do
+      let(:html_content) do
+        build_table(<<~HTML)
+          <tr></tr>
+          <tr>
+            <td>1</td>
+          </tr>
+        HTML
+      end
+
+      it '空行はスキップする' do
+        result = scraper.scrape
+        expect(result.length).to eq 1
+      end
+    end
+
+    context '複数行が存在する場合' do
+      let(:html_content) do
+        build_table(<<~HTML)
+          <tr><td>1</td></tr>
+          <tr><td>2</td></tr>
+          <tr><td>3</td></tr>
+        HTML
+      end
+
+      it '全行のデータを返す' do
+        result = scraper.scrape
+        expect(result.length).to eq 3
+      end
+    end
+
+    context '#js-playerTableが存在しない場合' do
+      let(:html_content) { '<html><body><p>テーブルなし</p></body></html>' }
+
+      it '空配列を返す' do
+        expect(scraper.scrape).to eq []
+      end
+    end
+
+    context 'テーブルにデータ行が存在しない場合' do
+      let(:html_content) { build_table('') }
+
+      it '空配列を返す' do
+        expect(scraper.scrape).to eq []
+      end
+    end
+  end
+
+  describe '#initialize (html取得)' do
+    context 'HTTPリクエストが成功する場合' do
+      let(:html_content) { '<html><body></body></html>' }
+
+      it 'charsetを取得して設定する' do
+        scraper
+        expect(scraper.instance_variable_get(:@charset)).to eq 'utf-8'
+      end
+
+      it 'HTMLコンテンツを取得する' do
+        scraper
+        expect(scraper.instance_variable_get(:@html)).to eq html_content
+      end
+    end
+
+    context 'OpenURI::HTTPErrorが発生する場合' do
+      let(:html_content) { '' }
+
+      before do
+        allow(Kernel).to receive(:sleep)
+        call_count = 0
+        allow(URI).to receive(:open).with(url) do
+          call_count += 1
+          raise OpenURI::HTTPError.new('503 Service Unavailable', StringIO.new)
+        end
+      end
+
+      it '3回リトライ後に例外を発生させる' do
+        expect { described_class.new(url) }.to raise_error(OpenURI::HTTPError)
+      end
+
+      it 'URI.openを3回呼び出す' do
+        expect(URI).to receive(:open).with(url).exactly(3).times
+          .and_raise(OpenURI::HTTPError.new('503', StringIO.new))
+        expect { described_class.new(url) }.to raise_error(OpenURI::HTTPError)
+      end
+    end
+
+    context '1回失敗して2回目で成功する場合' do
+      let(:html_content) { '<html><body></body></html>' }
+
+      before do
+        allow(Kernel).to receive(:sleep)
+        attempt = 0
+        allow(URI).to receive(:open).with(url) do |&block|
+          attempt += 1
+          if attempt == 1
+            raise OpenURI::HTTPError.new('503', StringIO.new)
+          else
+            block.call(mock_file)
+          end
+        end
+      end
+
+      it 'リトライ後に正常にHTMLを取得する' do
+        expect { described_class.new(url) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,4 +64,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/api/v1/favorite_batters_spec.rb
+++ b/spec/requests/api/v1/favorite_batters_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::FavoriteBatters', type: :request do
+  let(:team) { create(:team) }
+  let(:user) { create(:user, confirmed_at: Time.current) }
+  let!(:batter) { create(:batter, team: team) }
+
+  describe 'POST /api/v1/favorite_batters' do
+    context '認証済みユーザーの場合' do
+      before { sign_in user }
+
+      it 'favorite_batterを作成する' do
+        expect {
+          post '/api/v1/favorite_batters', params: { player_id: batter.id }
+        }.to change(FavoriteBatter, :count).by(1)
+      end
+
+      it '該当ユーザーのfavorite_batterが作成される' do
+        post '/api/v1/favorite_batters', params: { player_id: batter.id }
+        expect(user.favorite_batters.find_by(batter_id: batter.id)).to be_present
+      end
+    end
+
+    context '未認証の場合' do
+      it '401を返す' do
+        post '/api/v1/favorite_batters', params: { player_id: batter.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'レコードを作成しない' do
+        expect {
+          post '/api/v1/favorite_batters', params: { player_id: batter.id }
+        }.not_to change(FavoriteBatter, :count)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/favorite_batters' do
+    context '認証済みユーザーの場合' do
+      before do
+        sign_in user
+        create(:favorite_batter, user: user, batter: batter)
+      end
+
+      it 'favorite_batterを削除する' do
+        expect {
+          delete '/api/v1/favorite_batters', params: { player_id: batter.id }
+        }.to change(FavoriteBatter, :count).by(-1)
+      end
+    end
+
+    context '未認証の場合' do
+      before { create(:favorite_batter, user: user, batter: batter) }
+
+      it '401を返す' do
+        delete '/api/v1/favorite_batters', params: { player_id: batter.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'レコードを削除しない' do
+        expect {
+          delete '/api/v1/favorite_batters', params: { player_id: batter.id }
+        }.not_to change(FavoriteBatter, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/favorite_pitchers_spec.rb
+++ b/spec/requests/api/v1/favorite_pitchers_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::FavoritePitchers', type: :request do
+  let(:team) { create(:team) }
+  let(:user) { create(:user, confirmed_at: Time.current) }
+  let!(:pitcher) { create(:pitcher, team: team) }
+
+  describe 'POST /api/v1/favorite_pitchers' do
+    context '認証済みユーザーの場合' do
+      before { sign_in user }
+
+      it 'favorite_pitcherを作成する' do
+        expect {
+          post '/api/v1/favorite_pitchers', params: { player_id: pitcher.id }
+        }.to change(FavoritePitcher, :count).by(1)
+      end
+
+      it '該当ユーザーのfavorite_pitcherが作成される' do
+        post '/api/v1/favorite_pitchers', params: { player_id: pitcher.id }
+        expect(user.favorite_pitchers.find_by(pitcher_id: pitcher.id)).to be_present
+      end
+    end
+
+    context '未認証の場合' do
+      it '401を返す' do
+        post '/api/v1/favorite_pitchers', params: { player_id: pitcher.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'レコードを作成しない' do
+        expect {
+          post '/api/v1/favorite_pitchers', params: { player_id: pitcher.id }
+        }.not_to change(FavoritePitcher, :count)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/favorite_pitchers' do
+    context '認証済みユーザーの場合' do
+      before do
+        sign_in user
+        create(:favorite_pitcher, user: user, pitcher: pitcher)
+      end
+
+      it 'favorite_pitcherを削除する' do
+        expect {
+          delete '/api/v1/favorite_pitchers', params: { player_id: pitcher.id }
+        }.to change(FavoritePitcher, :count).by(-1)
+      end
+    end
+
+    context '未認証の場合' do
+      before { create(:favorite_pitcher, user: user, pitcher: pitcher) }
+
+      it '401を返す' do
+        delete '/api/v1/favorite_pitchers', params: { player_id: pitcher.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'レコードを削除しない' do
+        expect {
+          delete '/api/v1/favorite_pitchers', params: { player_id: pitcher.id }
+        }.not_to change(FavoritePitcher, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/players_spec.rb
+++ b/spec/requests/api/v1/players_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/players', type: :request do
+  let(:team) { create(:team) }
+
+  describe 'GET /api/v1/players' do
+    context 'データが存在しない場合' do
+      before { get '/api/v1/players' }
+
+      it '200を返す' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'central/pacificキーを含むJSONを返す' do
+        json = response.parsed_body
+        expect(json.keys).to contain_exactly('central', 'pacific')
+      end
+    end
+
+    context '選手データが存在する場合' do
+      before do
+        create(:batter, team: team, number: '1')
+        create(:pitcher, team: team, number: '18')
+        get '/api/v1/players'
+      end
+
+      it '200を返す' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'チームのリーグに応じたキーにデータが格納される' do
+        json = response.parsed_body
+        league_key = team.league
+        expect(json[league_key].length).to eq 1
+      end
+
+      it 'チームデータにname/formal_name/batters/pitchersが含まれる' do
+        json = response.parsed_body
+        league_key = team.league
+        team_data = json[league_key].first
+        expect(team_data.keys).to include('name', 'formal_name', 'batters', 'pitchers')
+      end
+
+      it '認証なしでアクセスできる' do
+        get '/api/v1/players'
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/registered_players_spec.rb
+++ b/spec/requests/api/v1/registered_players_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/registered_players', type: :request do
+  let(:team) { create(:team) }
+  let(:user) { create(:user, confirmed_at: Time.current) }
+
+  describe 'GET /api/v1/registered_players' do
+    context '認証済みユーザーの場合' do
+      before { sign_in user }
+
+      context 'お気に入り選手が存在しない場合' do
+        before { get '/api/v1/registered_players' }
+
+        it '200を返す' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'batters/pitchersキーを含むJSONを返す' do
+          json = response.parsed_body
+          expect(json.keys).to contain_exactly('batters', 'pitchers')
+        end
+
+        it 'battersが空配列である' do
+          expect(response.parsed_body['batters']).to eq []
+        end
+
+        it 'pitchersが空配列である' do
+          expect(response.parsed_body['pitchers']).to eq []
+        end
+      end
+
+      context 'お気に入り選手が存在する場合' do
+        let!(:batter) { create(:batter, team: team) }
+        let!(:pitcher) { create(:pitcher, team: team) }
+        let!(:favorite_batter) { create(:favorite_batter, user: user, batter: batter) }
+        let!(:favorite_pitcher) { create(:favorite_pitcher, user: user, pitcher: pitcher) }
+
+        before { get '/api/v1/registered_players' }
+
+        it 'battersに登録済み打者が含まれる' do
+          batter_names = response.parsed_body['batters'].map { |b| b['name'] }
+          expect(batter_names).to include(batter.name)
+        end
+
+        it 'pitchersに登録済み投手が含まれる' do
+          pitcher_names = response.parsed_body['pitchers'].map { |p| p['name'] }
+          expect(pitcher_names).to include(pitcher.name)
+        end
+
+        it 'batterデータにbatter_idが含まれる' do
+          expect(response.parsed_body['batters'].first['batter_id']).to eq batter.id
+        end
+
+        it 'pitcherデータにpitcher_idが含まれる' do
+          expect(response.parsed_body['pitchers'].first['pitcher_id']).to eq pitcher.id
+        end
+
+        it '他ユーザーのお気に入りは含まれない' do
+          other_user = create(:user, email: 'other@example.com', confirmed_at: Time.current)
+          other_batter = create(:batter, team: team, url: 'https://example.com/other', name: '他の選手')
+          create(:favorite_batter, user: other_user, batter: other_batter)
+
+          batter_names = response.parsed_body['batters'].map { |b| b['name'] }
+          expect(batter_names).not_to include('他の選手')
+        end
+      end
+    end
+
+    context '未認証の場合' do
+      it '401を返す' do
+        get '/api/v1/registered_players'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/system/registered_players_spec.rb
+++ b/spec/system/registered_players_spec.rb
@@ -114,6 +114,8 @@ RSpec.describe '登録済み選手一覧', type: :system do
     context '登録済みの選手が存在する場合' do
       include_context '選手登録済み'
 
+      before { visit registered_players_path }
+
       it '登録済みの野手が表示されること' do
         expect(page).to have_content '前田 智徳'
         expect(page).to have_content '新井 貴浩'

--- a/spec/system/registered_players_spec.rb
+++ b/spec/system/registered_players_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe '登録済み選手一覧', type: :system do
       end
 
       context '防御率のボタンをクリックした場合' do
-        before { click_on '防御率' }
+        before { find('th', text: '防御率').find('button').click }
 
         it '防御率の昇順で並び替えられること' do
           expect(page).to have_selector 'tbody tr:nth-child(1)', text: '黒田 博樹'
@@ -211,7 +211,7 @@ RSpec.describe '登録済み選手一覧', type: :system do
         end
 
         context '防御率のボタンをもう一度クリックした場合' do
-          before { click_on '防御率' }
+          before { find('th', text: '防御率').find('button').click }
 
           it '防御率の降順で並び替えられること' do
             expect(page).to have_selector 'tbody tr:nth-child(1)', text: '野村 祐輔'


### PR DESCRIPTION
close #15 #23

## 概要
モデル層およびAPI層のテストカバレッジを拡充するため、主要なモデルのユニットテストと`/api/v1/`配下のリクエストスペックを新規追加した。あわせてCIワークフローを整備し、CI上でテストが安定して通るよう周辺設定を修正した。

## 変更内容

### テスト追加
- `BatterScore` / `PitcherScore` / `PlayersDataFormatter` / `ScoreScraper` のモデルユニットテストを追加
- `FavoriteBatter` / `FavoritePitcher` のFactoryBotファクトリを追加
- `/api/v1/players` / `/api/v1/favorite_batters` / `/api/v1/favorite_pitchers` / `/api/v1/registered_players` のリクエストスペックを追加
- 登録済み選手一覧画面にアクセスするシステムテストを追加
- `spec/rails_helper.rb` にサポート設定を追加

### CI / 環境周り
- GitHub Actions のCIワークフロー (`.github/workflows/ci.yml`) を追加し、RuboCopおよびRSpecの実行を設定
- CI上でテストが落ちる問題を修正
- DBセットアップ手順を `db:prepare` から `db:create db:schema:load` に変更
- RubyGemsの設定を追加
- `selenium-webdriver` を 4.16 に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)