### PR TITLE
Tier1のシステムテストを追加

### DIFF
--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '未ログイン時のアクセス制御', type: :system do
+  context '未ログインで登録済み選手一覧にアクセスした場合' do
+    before { visit registered_players_path }
+
+    it 'ログイン画面にリダイレクトされること' do
+      expect(page).to have_current_path(new_user_session_path)
+      expect(page).to have_content 'パスワードを忘れましたか？'
+    end
+  end
+
+  context '未ログインで選手検索画面にアクセスした場合' do
+    before { visit players_path }
+
+    it 'ログイン画面にリダイレクトされること' do
+      expect(page).to have_current_path(new_user_session_path)
+      expect(page).to have_content 'パスワードを忘れましたか？'
+    end
+  end
+end

--- a/spec/system/registered_players_spec.rb
+++ b/spec/system/registered_players_spec.rb
@@ -338,5 +338,36 @@ RSpec.describe '登録済み選手一覧', type: :system do
         end
       end
     end
+
+    context '投手タブでチェックボックスを2つチェックした時' do
+      before do
+        visit registered_players_path
+        find('div.v-tab', text: '投手').click
+        expect(page).to have_selector 'tbody tr', text: '黒田 博樹'
+        expect(page).to have_selector 'tbody tr', text: '野村 祐輔'
+        find('tbody tr', text: '黒田 博樹').find('input[type="checkbox"]').set(true)
+        find('tbody tr', text: '野村 祐輔').find('input[type="checkbox"]').set(true)
+      end
+
+      context '比較するボタンをクリックした時' do
+        before { click_on '比較する' }
+
+        it '投手の比較モーダルが開き、優れている指標が強調されること' do
+          within('.v-card.v-sheet.theme--light') do
+            expect(page).to have_content '黒田 博樹'
+            expect(page).to have_content '野村 祐輔'
+            # 防御率は値が小さい方が優れる
+            expect(find('tr td.emphasis', text: '1.85'))
+            expect(find('tr td', text: '2.71'))
+            # 勝利数は値が大きい方が優れる
+            expect(find('tr td.emphasis', text: '16'))
+            expect(find('tr td', text: '13'))
+            # 奪三振は値が大きい方が優れる
+            expect(find('tr td.emphasis', text: '144'))
+            expect(find('tr td', text: '91'))
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/system/registered_players_spec.rb
+++ b/spec/system/registered_players_spec.rb
@@ -211,7 +211,10 @@ RSpec.describe '登録済み選手一覧', type: :system do
         end
 
         context '防御率のボタンをもう一度クリックした場合' do
-          before { find('th', text: '防御率').find('button').click }
+          before do
+            expect(page).to have_selector 'tbody tr:nth-child(1)', text: '黒田 博樹'
+            find('th', text: '防御率').find('button').click
+          end
 
           it '防御率の降順で並び替えられること' do
             expect(page).to have_selector 'tbody tr:nth-child(1)', text: '野村 祐輔'
@@ -222,7 +225,7 @@ RSpec.describe '登録済み選手一覧', type: :system do
       end
 
       context '勝のボタンをクリックした場合' do
-        before { click_on '勝' }
+        before { find('th', text: '勝').find('button').click }
 
         it '勝利数の降順で並び替えられること' do
           expect(page).to have_selector 'tbody tr:nth-child(1)', text: '野村 祐輔'
@@ -347,6 +350,7 @@ RSpec.describe '登録済み選手一覧', type: :system do
         expect(page).to have_selector 'tbody tr', text: '野村 祐輔'
         find('tbody tr', text: '黒田 博樹').find('input[type="checkbox"]').set(true)
         find('tbody tr', text: '野村 祐輔').find('input[type="checkbox"]').set(true)
+        expect(page).to have_button '比較する', disabled: false
       end
 
       context '比較するボタンをクリックした時' do

--- a/spec/system/team_players_spec.rb
+++ b/spec/system/team_players_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe '選手一覧画面', type: :system do
       expect(page).to have_content '選手を登録しました'
     end
 
+    it '+ボタンで登録した選手が登録済み選手一覧画面に表示されること' do
+      click_on '広島東洋カープ'
+      first('button.light-green').click
+      expect(page).to have_content '選手を登録しました'
+      visit registered_players_path
+      expect(page).to have_content '田村 俊介'
+    end
+
     context '登録済みの選手の場合' do
       before do
         FavoriteBatter.create!(user: user, batter: batter)


### PR DESCRIPTION
## 概要
未ログイン時のアクセス制御、選手登録後の登録済み一覧への反映、投手比較モーダルの優位指標強調表示について、優先度の高いシナリオをカバーするシステムテストを追加した。

## 変更内容
- `spec/system/authentication_spec.rb` を新規追加し、未ログインで `registered_players_path` / `players_path` にアクセスするとログイン画面へリダイレクトされることを検証
- `spec/system/registered_players_spec.rb` に投手タブでの比較モーダルのテストを追加し、防御率・勝利数・奪三振の優劣強調表示を検証
- `spec/system/team_players_spec.rb` に、＋ボタンで登録した選手が登録済み選手一覧画面に反映されることを検証するケースを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)