### PR TITLE
docs: CLAUDE.md のスタック表記を Ruby 3.2.11 / Rails 7.0.10 に更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ docker compose up   # PostgreSQL (5433) + webpack-dev-server (3035)
 
 NPBプロ野球選手の統計情報をYahoo Sports Japanからスクレイピングし、ユーザーがお気に入り選手を登録・比較・閲覧できるWebアプリ。
 
-**スタック**: Ruby 3.0.6 / Rails 6.0.6.1 / PostgreSQL / Vue.js 2 + Vuex + Vuetify 2 / Webpacker / Slim
+**スタック**: Ruby 3.2.11 / Rails 7.0.10 / PostgreSQL / Vue.js 2 + Vuex + Vuetify 2 / Webpacker / Slim
 
 ### データフロー
 


### PR DESCRIPTION
## 概要
PR #128（Rails 6.1 → 7.0 アップグレード）のマージ時に `CLAUDE.md` のスタック表記を更新し忘れており、Ruby 3.0.6 / Rails 6.0.6.1 という古いバージョンのまま残っていた。実際のバージョン（`.ruby-version` / `Gemfile.lock`）に合わせて修正する。

## 変更内容
- `CLAUDE.md` のアーキテクチャ節: `Ruby 3.0.6 / Rails 6.0.6.1` → `Ruby 3.2.11 / Rails 7.0.10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)